### PR TITLE
fix(ipa0125): Add discriminator and oneOf property guidance

### DIFF
--- a/ipa/general/0125.md
+++ b/ipa/general/0125.md
@@ -25,10 +25,13 @@ state management.
   and response objects allow explicitly setting the type of the object
   - In OpenAPI each `oneOf` property **must** be accompanied by a
     `discriminator` property defining when the exact type will be used
+  - In OpenAPI each `discriminator` property **must** be accompanied by a 
+        `oneOf`, `anyOf` or `allOf` property
+  - If multiple `oneOf` models define a property with the same name, that property **must** have the type in each model
 
 ## Example
 
-Avoid this design:
+Avoid this design, using the same field for multiple types:
 
 ```http
 POST /groups/search/index
@@ -37,7 +40,7 @@ POST /groups/search/index
 }
 ```
 
-Preferred design:
+Preferred design, splitting the field into distinct types:
 
 ```http
 POST /groups/search/index

--- a/ipa/general/0125.md
+++ b/ipa/general/0125.md
@@ -25,9 +25,10 @@ state management.
   and response objects allow explicitly setting the type of the object
   - In OpenAPI each `oneOf` property **must** be accompanied by a
     `discriminator` property defining when the exact type will be used
-  - In OpenAPI each `discriminator` property **must** be accompanied by a 
-        `oneOf`, `anyOf` or `allOf` property
-  - If multiple `oneOf` models define a property with the same name, that property **must** have the type in each model
+  - In OpenAPI each `discriminator` property **must** be accompanied by a
+    `oneOf`, `anyOf` or `allOf` property
+  - If multiple `oneOf` models define a property with the same name, that
+    property **must** have the type in each model
 
 ## Example
 


### PR DESCRIPTION
Adds clarifying guidance to IPA 125:
- If a discriminator property is present, there must be a `oneOf`, `anyOf` or `allOf` property
- If multiple `oneOf` models define a property with the same name, that property **must** have the type in each model

Tickets: [CLOUDP-308542](https://jira.mongodb.org/browse/CLOUDP-308542) and [CLOUDP-309117](https://jira.mongodb.org/browse/CLOUDP-309117)

Will follow-up with IPA validation