### PR TITLE
fix(ipa0123): Clarify the enum/string field usage guideline

### DIFF
--- a/ipa/general/0123.md
+++ b/ipa/general/0123.md
@@ -23,9 +23,9 @@ the expectation for that data field.
   values
   - Enums **must not** be extended in a non-compatible fashion. I.e. splitting
     one enum value into two
-- API producers **should** use a string field if allowed enum values change
+- API producers **should** use a string field if allowable enum values change
   often or exceed **20**
-  - If so, API producers **must** document the allowed values.
+  - If so, API producers **must** document the allowable values.
 
 Example:
 

--- a/ipa/general/0123.md
+++ b/ipa/general/0123.md
@@ -23,9 +23,9 @@ the expectation for that data field.
   values
   - Enums **must not** be extended in a non-compatible fashion. I.e. splitting
     one enum value into two
-- API producers **should** use a string field when the set of allowed enum
-  values changes frequently or when the list exceeds **20** values, and **must**
-  document the allowed values.
+- API producers **should** use a string field if allowed enum values change
+  often or exceed **20**
+  - If so, API producers **must** document the allowed values.
 
 Example:
 

--- a/ipa/general/0123.md
+++ b/ipa/general/0123.md
@@ -23,10 +23,14 @@ the expectation for that data field.
   values
   - Enums **must not** be extended in a non-compatible fashion. I.e. splitting
     one enum value into two
-- API producers **should** use a string field when the set of allowed enum values changes frequently or when the list exceeds **20** values, and **must** document the allowed values.
+- API producers **should** use a string field when the set of allowed enum
+  values changes frequently or when the list exceeds **20** values, and **must**
+  document the allowed values.
 
 Example:
+
 - Stable Enum (small, rarely changes)
+
 ```yaml
 type: string
 title: Alert Audit Types
@@ -35,14 +39,16 @@ enum:
   - ALERT_ACKNOWLEDGED_AUDIT
   - ALERT_UNACKNOWLEDGED_AUDIT
 ```
+
 - Dynamic or Large Enum Set (changing often or > 20 values)
+
 ```yaml
 type: string
 title: Alert Audit Type
 description: >
-  String identifying the type of alert audit action.
-  The list of allowed values changes frequently or is extensive (>20).
-  Refer to the API documentation for the current list of allowed values.
+  String identifying the type of alert audit action. The list of allowed values
+  changes frequently or is extensive (>20). Refer to the API documentation for
+  the current list of allowed values.
 example: ALERT_ACKNOWLEDGED_AUDIT
 externalDocs:
   description: Current list of allowed values for Alert Audit Type

--- a/ipa/general/0123.md
+++ b/ipa/general/0123.md
@@ -23,4 +23,28 @@ the expectation for that data field.
   values
   - Enums **must not** be extended in a non-compatible fashion. I.e. splitting
     one enum value into two
-- API producers **should** opt for a string when allowable enum values exceed 20
+- API producers **should** use a string field when the set of allowed enum values changes frequently or when the list exceeds **20** values, and **must** document the allowed values.
+
+Example:
+- Stable Enum (small, rarely changes)
+```yaml
+type: string
+title: Alert Audit Types
+description: Type of alert audit action.
+enum:
+  - ALERT_ACKNOWLEDGED_AUDIT
+  - ALERT_UNACKNOWLEDGED_AUDIT
+```
+- Dynamic or Large Enum Set (changing often or > 20 values)
+```yaml
+type: string
+title: Alert Audit Type
+description: >
+  String identifying the type of alert audit action.
+  The list of allowed values changes frequently or is extensive (>20).
+  Refer to the API documentation for the current list of allowed values.
+example: ALERT_ACKNOWLEDGED_AUDIT
+externalDocs:
+  description: Current list of allowed values for Alert Audit Type
+  url: link/to/docs/Alert+Audit+Types
+```


### PR DESCRIPTION
Adds clarifying guidance to IPA-123: Enums

- Include OpenAPI spec examples.
- If a string field is used instead of an enum, API producers must document the allowed values.

**Note**: The current validation only checks if the enum list exceeds 20 values. It does/can not detect when a string field is used in place of an enum, so reviewers should watch for this during reviews.