### PR TITLE
fix(ipa0117): Clarify schema descriptions

### DIFF
--- a/ipa/general/0117.md
+++ b/ipa/general/0117.md
@@ -21,6 +21,8 @@ will promote clarity, completeness and consistency.
   - Operations
   - Parameters
   - Tags
+- API producers **may** provide descriptions for:
+  - Schemas
 - Descriptions **should** be complete but brief
   - Descriptions **should** aim to cover
     - What it is


### PR DESCRIPTION
Including schema descriptions in IPA 117 guidelines. Though not required, if present they follow the same guidelines as all descriptions.