### PR TITLE
fix(ipa0117): Clarify what an Operation Summary is

### DIFF
--- a/ipa/general/0117.md
+++ b/ipa/general/0117.md
@@ -41,7 +41,7 @@ will promote clarity, completeness and consistency.
   - See
     [External Documentation Object](https://swagger.io/specification/#external-documentation-object)
 
-#### Formatting
+#### Description Formatting
 
 - Description **may** use [CommonMark](https://commonmark.org/)
 - Descriptions **must** start with Uppercase and end with a full stop(.)
@@ -101,10 +101,23 @@ will promote clarity, completeness and consistency.
 
 ### Operation Summary
 
-- API Producers **must** use
-  [Title Case](https://en.wikipedia.org/wiki/Title_case)
+Operation summaries are titles describing an API operation.
+
+- Operation summaries **must** be concise
+- Operation summaries **should** describe what an operation does, but **should
+  not** describe in-depths information about how to use it or nuances in
+  behavior
+  - For additional details about the behaviour of the operations, refer to
+    [Descriptions](#descriptions)
+
+#### Formatting
+
+- Summaries **must** use [Title Case](https://en.wikipedia.org/wiki/Title_case)
 - Summaries **must not** end with a period
 - Summaries **must not** use [CommonMark](https://commonmark.org/)
+
+#### Language
+
 - API Producers **must** use "One" when referring to a single item instead of
   "a" or "specified"
 - "Remove" vs. "Delete"


### PR DESCRIPTION
[CLOUDP-319114](https://jira.mongodb.org/browse/CLOUDP-319114)

Clarified what an operation summary is, and how it differs from description. Essentially it's a title and should be very concise
