### PR TITLE
fix(ipa0005): exception naming and description format

### DIFF
--- a/ipa/general/0005.md
+++ b/ipa/general/0005.md
@@ -33,14 +33,19 @@ reasoning and history for the offending APIs.
 
 ### Exception Format
 
-- Exception rule names **must** start with `xgen-IPA-` prefix
 - API producers **must** adhere to a key-value format.
   - Each key represents the IPA rule name, and the value provides the
     corresponding justification.
-- API producers **must** provide an exception key that matches the rule name in
-  the following format: `xgen-IPA-XXX-{rule-name}`
+  - The key **must** start with `xgen-IPA-` prefix
+  - API producers **must** provide the exception key in the format: `xgen-IPA-<IPA-principle-number>-{rule-name}`
+  - For exceptions related to IPA validation rules:
+    - API producers **must** provide a key that matches the rule name in the IPA validation framework
+  - For exceptions related to unlintable IPA guidelines:
+    - API producers **must** provide a clear, descriptive rule name
 - API producers **must** provide a clear and concise explanation for why the
   exception is being applied
+  - Exception justification **must** start with an upper-case letter and end with
+    a full stop (.)
 - API producer **may** define multiple exceptions at the same level if needed
 
 Example


### PR DESCRIPTION
Modify the guidelines to cover unlintable IPA guideline exceptions and justification formatting