### PR TITLE
fix: Test docusaurus admonition

### DIFF
--- a/ipa/general/0001.md
+++ b/ipa/general/0001.md
@@ -12,8 +12,11 @@ teams discuss and come to a consensus on API guidance.
 
 The principles are not final and are subject to changes.
 
-> [!NOTE]  
-> **State:** Adopt
+:::info[State]
+
+Adopt
+
+:::
 
 ## Guidance
 


### PR DESCRIPTION
Admonitions/markdown alerts are not rendered properly on the IPA page right now. This PR will test going back to Docusaurus admonitions instead of the markdown/GH alerts, to see if it works. If so, I'll open a PR to fix all occurrences.

Ticket: [CLOUDP-331117](https://jira.mongodb.org/browse/CLOUDP-331117)