### PR TITLE
feat(docs): Add AI agent guidelines and API design workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ Thumbs.db
 # Logs
 logs/
 *.log
+
+# API Designs - local workspace only
+api-designs/*
+!api-designs/README.md
+!api-designs/.gitkeep

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,38 @@ help you understand our development process and requirements.
    npm run docusaurus:build
    ```
 
+## Working with AI Agents
+
+This repository includes comprehensive guidelines for AI agents to help with API design and review.
+
+### Agent Guidelines
+
+See [agents.md](agents.md) for detailed guidance on:
+- How AI agents should interpret and apply IPA guidelines
+- How to reference specific IPAs when making recommendations
+- Best practices for API design reviews and discussions
+- Example workflows and prompts for common tasks
+
+### API Designs Folder
+
+The `api-designs/` folder is a workspace for developing and reviewing API designs:
+
+- **Purpose**: Store OpenAPI specifications and design documents for IPA compliance review
+- **Structure**: Each project gets its own subdirectory with `openapi.yaml`, `design-notes.md`, and `ipa-compliance.md`
+- **Usage**: See [api-designs/README.md](api-designs/README.md) for detailed guidance
+
+### External Documentation
+
+The `docs/external/` folder contains documentation synced from external repositories:
+
+- **IPA Validation**: Spectral-based linting rules from the mongodb/openapi repository
+- **Updating**: Run `./scripts/update-external-docs.sh` to fetch the latest external documentation
+
+```bash
+# Update external documentation
+./scripts/update-external-docs.sh
+```
+
 ## Code Quality
 
 Before submitting your changes, ensure they pass our quality checks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,13 @@ help you understand our development process and requirements.
 
 ## Working with AI Agents
 
-This repository includes comprehensive guidelines for AI agents to help with API design and review.
+This repository includes comprehensive guidelines for AI agents to help with API
+design and review.
 
 ### Agent Guidelines
 
 See [agents.md](agents.md) for detailed guidance on:
+
 - How AI agents should interpret and apply IPA guidelines
 - How to reference specific IPAs when making recommendations
 - Best practices for API design reviews and discussions
@@ -48,18 +50,25 @@ See [agents.md](agents.md) for detailed guidance on:
 
 ### API Designs Folder
 
-The `api-designs/` folder is a workspace for developing and reviewing API designs:
+The `api-designs/` folder is a workspace for developing and reviewing API
+designs:
 
-- **Purpose**: Store OpenAPI specifications and design documents for IPA compliance review
-- **Structure**: Each project gets its own subdirectory with `openapi.yaml`, `design-notes.md`, and `ipa-compliance.md`
-- **Usage**: See [api-designs/README.md](api-designs/README.md) for detailed guidance
+- **Purpose**: Store OpenAPI specifications and design documents for IPA
+  compliance review
+- **Structure**: Each project gets its own subdirectory with `openapi.yaml`,
+  `design-notes.md`, and `ipa-compliance.md`
+- **Usage**: See [api-designs/README.md](api-designs/README.md) for detailed
+  guidance
 
 ### External Documentation
 
-The `docs/external/` folder contains documentation synced from external repositories:
+The `docs/external/` folder contains documentation synced from external
+repositories:
 
-- **IPA Validation**: Spectral-based linting rules from the mongodb/openapi repository
-- **Updating**: Run `./scripts/update-external-docs.sh` to fetch the latest external documentation
+- **IPA Validation**: Spectral-based linting rules from the mongodb/openapi
+  repository
+- **Updating**: Run `./scripts/update-external-docs.sh` to fetch the latest
+  external documentation
 
 ```bash
 # Update external documentation

--- a/agents.md
+++ b/agents.md
@@ -250,7 +250,7 @@ Always document exceptions using the format from IPA-5 (see
 
 Use this format when citing IPAs:
 
-```
+```text
 According to IPA-XXX ([Title]), [specific guidance].
 ```
 
@@ -344,7 +344,7 @@ When reviewing API designs, agents should:
 
 **Example Agent Response**:
 
-```
+```text
 I see Spectral is reporting a `xgen-IPA-101-resource-oriented-design` error. This relates to
 IPA-101 (Resource-Oriented Design), which requires APIs to be organized around resources
 rather than actions.
@@ -398,7 +398,7 @@ x-xgen-IPA-exception:
 For a complete list of implemented linting rules, see:
 
 - **Ruleset Documentation**:
-  https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme
+  <https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme>
 - **Local Copy**:
   [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)
 
@@ -417,7 +417,7 @@ Common linting rules include:
 
 Store API designs in the `api-designs/` folder with this structure:
 
-```
+```text
 api-designs/
 ├── <project-name>/
 │   ├── openapi.yaml              # OpenAPI 3.x specification
@@ -520,7 +520,7 @@ When working with API designs in the `api-designs/` folder:
 
 **Example Agent Workflow**:
 
-```
+```text
 User: "Review my cluster API design"
 
 Agent:
@@ -542,7 +542,7 @@ AI agents when working with IPA guidelines.
 
 **User Prompt**:
 
-```
+```text
 Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
 ```
 
@@ -550,7 +550,7 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
 
 1. **Load the OpenAPI specification**
 
-   ```
+   ```text
    I'll review your cluster API design against IPA guidelines.
    ```
 
@@ -565,7 +565,7 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
 
 3. **Provide specific feedback with IPA citations**
 
-   ```
+   ```text
    ✅ IPA-101 (Resource-Oriented Design): Good! Using /api/v1/clusters/{clusterId}
 
    ⚠️  IPA-105 (LIST): The LIST operation is missing pagination parameters.
@@ -596,8 +596,8 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
 
 5. **Note any required exceptions**
 
-   ```
-   If you need to deviate from IPA-110 for legacy reasons, document it:
+   ```yaml
+   ? If you need to deviate from IPA-110 for legacy reasons, document it
 
    x-xgen-IPA-exception:
      xgen-IPA-110-pagination: |
@@ -609,7 +609,7 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
 
 **User Prompt**:
 
-```
+```text
 Help me design a new API for managing database backups following IPA guidelines
 ```
 
@@ -617,7 +617,7 @@ Help me design a new API for managing database backups following IPA guidelines
 
 1. **Start with resource-oriented design (IPA-101)**
 
-   ```
+   ```text
    Let's design a backup API following IPA guidelines. First, let's identify the resource:
 
    Resource: "backup" (plural: "backups")
@@ -626,7 +626,7 @@ Help me design a new API for managing database backups following IPA guidelines
 
 2. **Define resource identifiers (IPA-102)**
 
-   ```
+   ```text
    Backup identifiers should be:
    - Opaque (not expose internal structure)
    - Immutable (never change)
@@ -637,7 +637,7 @@ Help me design a new API for managing database backups following IPA guidelines
 
 3. **Plan standard methods (IPA-103-108)**
 
-   ```
+   ```text
    Standard methods for backups:
    - GET /api/v1/backups/{backupId} - Retrieve a backup
    - GET /api/v1/backups - List all backups (with pagination)
@@ -648,7 +648,7 @@ Help me design a new API for managing database backups following IPA guidelines
 
 4. **Consider pagination (IPA-110)**
 
-   ```
+   ```text
    For the LIST operation, include pagination:
 
    GET /api/v1/backups?pageToken={token}&pageSize=20
@@ -662,7 +662,7 @@ Help me design a new API for managing database backups following IPA guidelines
 
 5. **Plan error responses (IPA-114)**
 
-   ```
+   ```json
    Error response structure:
    {
      "error": {
@@ -677,7 +677,7 @@ Help me design a new API for managing database backups following IPA guidelines
 
 6. **Create OpenAPI spec in api-designs/backups/**
 
-   ```
+   ```text
    I'll create the following files:
    - api-designs/backups/openapi.yaml
    - api-designs/backups/design-notes.md
@@ -685,7 +685,7 @@ Help me design a new API for managing database backups following IPA guidelines
    ```
 
 7. **Document IPA compliance**
-   ```
+   ```text
    I'll create an IPA compliance checklist tracking which guidelines
    are followed and any exceptions needed.
    ```
@@ -694,7 +694,7 @@ Help me design a new API for managing database backups following IPA guidelines
 
 **User Prompt**:
 
-```
+```text
 Check if my API follows IPA-104 (GET method) requirements
 ```
 
@@ -702,7 +702,7 @@ Check if my API follows IPA-104 (GET method) requirements
 
 1. **Reference IPA-104 specific requirements**
 
-   ```
+   ```text
    I'll check your API against IPA-104 (GET) requirements:
 
    IPA-104 requires:
@@ -716,25 +716,25 @@ Check if my API follows IPA-104 (GET method) requirements
 
 2. **Check operation ID naming**
 
-   ```
+   ```text
    ✅ Operation ID: "getCluster" (camelCase, starts with "get")
    ```
 
 3. **Verify HTTP method**
 
-   ```
+   ```text
    ✅ Using HTTP GET method
    ```
 
 4. **Ensure no request body**
 
-   ```
+   ```text
    ✅ No request body defined
    ```
 
 5. **Check response schema structure**
 
-   ```
+   ```json
    ✅ Returns single cluster object
 
    Response schema:
@@ -747,7 +747,7 @@ Check if my API follows IPA-104 (GET method) requirements
 
 6. **Validate error handling references IPA-114**
 
-   ```
+   ```yaml
    ⚠️  Missing 404 error response for when cluster is not found.
 
    Add this to your GET operation:
@@ -765,7 +765,7 @@ Check if my API follows IPA-104 (GET method) requirements
 
 **User Prompt**:
 
-```
+```text
 I need to deviate from IPA-105 for legacy reasons. How should I document this?
 ```
 
@@ -773,7 +773,7 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
 
 1. **Reference IPA-5 (Documenting Exceptions)**
 
-   ```
+   ```text
    According to IPA-5 (Documenting Exceptions), you should document
    deviations using the x-xgen-IPA-exception extension.
    ```
@@ -795,7 +795,7 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
 
 3. **Help write clear justification**
 
-   ```
+   ```text
    Your exception documentation should include:
    - **Reason**: Why the exception is necessary
    - **Impact**: What IPA principle is being violated and consequences
@@ -805,7 +805,7 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
 
 4. **Suggest mitigation strategies**
 
-   ```
+   ```text
    Mitigation strategies for pagination exception:
    1. Document the limitation clearly in API documentation
    2. Set reasonable maximum page size (e.g., 100 items)
@@ -815,11 +815,13 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
 
 5. **Update design documentation**
 
-   ```
+   ```markdown
    Also update api-designs/clusters/ipa-compliance.md:
 
    ## Exceptions
+
    ### IPA-105: LIST Method
+
    **Reason**: Legacy pagination uses offset/limit instead of pageToken
    **Mitigation**: Documented in API, will migrate to pageToken in v2
    **Timeline**: Q2 2024
@@ -829,7 +831,7 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
 
 **User Prompt**:
 
-```
+```text
 I need to add a "restart cluster" operation. How should I design this following IPA guidelines?
 ```
 
@@ -837,14 +839,14 @@ I need to add a "restart cluster" operation. How should I design this following 
 
 1. **Reference IPA-109 (Custom Methods)**
 
-   ```
+   ```text
    This operation doesn't fit standard methods (GET, LIST, CREATE, UPDATE, DELETE),
    so we'll use a custom method per IPA-109 (Custom Methods).
    ```
 
 2. **Recommend custom method pattern**
 
-   ```
+   ```text
    According to IPA-109, custom methods should:
    - Use POST HTTP method
    - Use :verb suffix in URL
@@ -893,7 +895,7 @@ I need to add a "restart cluster" operation. How should I design this following 
    ```
 
 4. **Explain rationale**
-   ```
+   ```text
    Why this design follows IPA-109:
    - Uses POST (custom methods are not idempotent)
    - Uses :restart suffix (clear action verb)
@@ -1002,19 +1004,19 @@ When reviewing or designing APIs, these IPAs are most frequently applicable:
 
 ### Key Links
 
-| Resource                      | Link                                                                             |
-| ----------------------------- | -------------------------------------------------------------------------------- |
-| **IPA Documentation**         | https://mongodb.github.io/ipa/                                                   |
-| **IPA Validation (Spectral)** | [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md) |
-| **Spectral Ruleset**          | https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme  |
-| **API Designs Folder**        | [api-designs/](api-designs/)                                                     |
-| **Contributing**              | [CONTRIBUTING.md](CONTRIBUTING.md)                                               |
+| Resource                      | Link                                                                              |
+| ----------------------------- | --------------------------------------------------------------------------------- |
+| **IPA Documentation**         | <https://mongodb.github.io/ipa/>                                                  |
+| **IPA Validation (Spectral)** | [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)  |
+| **Spectral Ruleset**          | <https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme> |
+| **API Designs Folder**        | [api-designs/](api-designs/)                                                      |
+| **Contributing**              | [CONTRIBUTING.md](CONTRIBUTING.md)                                                |
 
 ### Common IPA Patterns
 
 #### Resource URL Pattern
 
-```
+```text
 /api/v{majorVersion}/{resourcePlural}/{resourceId}
 ```
 
@@ -1026,7 +1028,7 @@ Examples:
 
 #### Standard Method URLs
 
-```
+```text
 GET    /api/v1/clusters/{clusterId}      # Get single resource
 GET    /api/v1/clusters                  # List resources
 POST   /api/v1/clusters                  # Create resource
@@ -1036,7 +1038,7 @@ DELETE /api/v1/clusters/{clusterId}      # Delete resource
 
 #### Custom Method URL
 
-```
+```text
 POST /api/v1/clusters/{clusterId}:restart
 POST /api/v1/backups/{backupId}:restore
 POST /api/v1/databases/{databaseId}:export
@@ -1044,7 +1046,7 @@ POST /api/v1/databases/{databaseId}:export
 
 #### Pagination Parameters
 
-```
+```text
 GET /api/v1/clusters?pageToken={token}&pageSize=20
 ```
 
@@ -1154,7 +1156,7 @@ Don't just enforce rules. Explain:
 
 **Example**:
 
-```
+```text
 IPA-110 (Pagination) requires using pageToken instead of offset/limit because:
 - Tokens are stable even when data changes
 - Prevents skipped or duplicate items during pagination

--- a/agents.md
+++ b/agents.md
@@ -309,52 +309,6 @@ MongoDB provides two complementary approaches to IPA compliance:
   [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)
   for complete linting documentation
 
-### Using Spectral for IPA Validation
-
-#### Installation
-
-```bash
-npm install @mongodb-js/ipa-validation-ruleset
-```
-
-#### Configuration
-
-Create a `.spectral.yaml` file in your project:
-
-```yaml
-extends:
-  - "@mongodb/ipa-validation-ruleset"
-```
-
-#### Running Validation
-
-```bash
-npx spectral lint path/to/openapi.yaml --ruleset=.spectral.yaml
-```
-
-#### Integration with AI Agent Workflows
-
-When reviewing API designs, agents should:
-
-1. **Suggest running Spectral validation** to catch automated issues
-2. **Interpret Spectral errors** and relate them back to IPA guidelines
-3. **Provide context** for why the linting rule exists
-4. **Suggest fixes** that address both the linting error and the underlying IPA
-   principle
-
-**Example Agent Response**:
-
-```text
-I see Spectral is reporting a `xgen-IPA-101-resource-oriented-design` error. This relates to
-IPA-101 (Resource-Oriented Design), which requires APIs to be organized around resources
-rather than actions.
-
-Current: POST /api/createCluster
-Suggested: POST /api/v1/clusters
-
-This change makes the API more intuitive and consistent with REST principles.
-```
-
 ### Documenting IPA Exceptions
 
 When an API must deviate from IPA guidelines, document the exception using the
@@ -420,25 +374,25 @@ Store API designs in the `api-designs/` folder with this structure:
 ```text
 api-designs/
 ├── <project-name>/
-│   ├── openapi.yaml              # OpenAPI 3.x specification
+│   ├── api-design.md             # API design document in markdown
 │   ├── design-notes.md           # Design rationale and decisions
-│   ├── ipa-compliance.md         # IPA compliance checklist
-│   └── .spectral.yaml            # (Optional) Spectral configuration
+│   └── ipa-compliance.md         # IPA compliance checklist
 └── README.md                     # Usage guide
 ```
 
 ### What to Include in API Design Documents
 
-#### openapi.yaml (Required)
+#### api-design.md (Required)
 
-The OpenAPI 3.x specification following IPA guidelines. Include:
+The API design document in markdown format following IPA guidelines. Include:
 
-- Complete resource definitions
-- All standard methods (GET, LIST, CREATE, UPDATE, DELETE)
+- Resource definitions and hierarchies
+- All standard methods (GET, LIST, CREATE, UPDATE, DELETE) with examples
 - Custom methods if needed
-- Error responses
-- Pagination parameters for LIST operations
-- Proper versioning in the URL path
+- Request and response formats
+- Error response structures
+- Pagination approach for LIST operations
+- Versioning strategy
 
 #### design-notes.md (Recommended)
 
@@ -511,12 +465,13 @@ When working with API designs in the `api-designs/` folder:
 
 1. **Check for existing designs first**: Before creating a new design, search
    for existing work
-2. **Load all relevant files**: Read openapi.yaml, design-notes.md, and
+2. **Load all relevant files**: Read api-design.md, design-notes.md, and
    ipa-compliance.md together
 3. **Suggest improvements**: Based on IPA guidelines, recommend specific changes
-4. **Update documentation**: When modifying openapi.yaml, also update
+4. **Update documentation**: When modifying api-design.md, also update
    design-notes.md and ipa-compliance.md
-5. **Run validation**: Suggest running Spectral validation after changes
+5. **Provide examples**: Show concrete examples of how to structure endpoints
+   and responses
 
 **Example Agent Workflow**:
 
@@ -524,13 +479,12 @@ When working with API designs in the `api-designs/` folder:
 User: "Review my cluster API design"
 
 Agent:
-1. Loads api-designs/clusters/openapi.yaml
+1. Loads api-designs/clusters/api-design.md
 2. Loads api-designs/clusters/ipa-compliance.md
 3. Reviews against relevant IPAs (101, 102, 103-108, 110, 114, 116, 120)
 4. Identifies issues: "Missing pagination on LIST operation (IPA-110)"
-5. Suggests fix with code example
+5. Suggests fix with markdown example
 6. Recommends updating ipa-compliance.md checklist
-7. Suggests running: npx spectral lint api-designs/clusters/openapi.yaml
 ```
 
 ## Example Workflows & Prompts
@@ -543,12 +497,12 @@ AI agents when working with IPA guidelines.
 **User Prompt**:
 
 ```text
-Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
+Review my API design in api-designs/clusters/api-design.md against IPA guidelines
 ```
 
 **Agent Response Pattern**:
 
-1. **Load the OpenAPI specification**
+1. **Load the API design document**
 
    ```text
    I'll review your cluster API design against IPA guidelines.
@@ -675,11 +629,11 @@ Help me design a new API for managing database backups following IPA guidelines
    }
    ```
 
-6. **Create OpenAPI spec in api-designs/backups/**
+6. **Create API design in api-designs/backups/**
 
    ```text
    I'll create the following files:
-   - api-designs/backups/openapi.yaml
+   - api-designs/backups/api-design.md
    - api-designs/backups/design-notes.md
    - api-designs/backups/ipa-compliance.md
    ```
@@ -1004,13 +958,12 @@ When reviewing or designing APIs, these IPAs are most frequently applicable:
 
 ### Key Links
 
-| Resource                      | Link                                                                              |
-| ----------------------------- | --------------------------------------------------------------------------------- |
-| **IPA Documentation**         | <https://mongodb.github.io/ipa/>                                                  |
-| **IPA Validation (Spectral)** | [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)  |
-| **Spectral Ruleset**          | <https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme> |
-| **API Designs Folder**        | [api-designs/](api-designs/)                                                      |
-| **Contributing**              | [CONTRIBUTING.md](CONTRIBUTING.md)                                                |
+| Resource                     | Link                                                                             |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| **IPA Documentation**        | <https://mongodb.github.io/ipa/>                                                 |
+| **IPA Validation Reference** | [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md) |
+| **API Designs Folder**       | [api-designs/](api-designs/)                                                     |
+| **Contributing**             | [CONTRIBUTING.md](CONTRIBUTING.md)                                               |
 
 ### Common IPA Patterns
 
@@ -1135,15 +1088,16 @@ Pay attention to IPA maturity:
 - **Deprecated**: Warn against use, suggest alternatives
 - **Retired**: Don't recommend, explain historical context if relevant
 
-### 7. Suggest Validation
+### 7. Provide Comprehensive Review
 
 After providing recommendations:
 
-- **Suggest Spectral validation**: "Run `npx spectral lint openapi.yaml` to
-  check for issues"
-- **Explain validation results**: Help interpret linting errors
-- **Provide fixes**: Show how to address validation failures
-- **Document exceptions**: Help write proper exception documentation
+- **Review against all relevant IPAs**: Check the design against applicable IPA
+  guidelines
+- **Explain findings**: Help developers understand why certain patterns are
+  recommended
+- **Provide concrete examples**: Show how to implement IPA-compliant designs
+- **Document exceptions**: Help write proper exception documentation when needed
 
 ### 8. Help Developers Understand "Why"
 

--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,9 @@
 # AI Agent Guidelines for MongoDB IPA
 
-This document provides guidance for AI agents (Augment, Claude, GitHub Copilot, etc.) and developers using them to effectively apply MongoDB's Improvement Proposal for APIs (IPA) guidelines when designing, reviewing, and implementing APIs.
+This document provides guidance for AI agents (Augment, Claude, GitHub Copilot,
+etc.) and developers using them to effectively apply MongoDB's Improvement
+Proposal for APIs (IPA) guidelines when designing, reviewing, and implementing
+APIs.
 
 ## Table of Contents
 
@@ -18,7 +21,10 @@ This document provides guidance for AI agents (Augment, Claude, GitHub Copilot, 
 
 ### Purpose
 
-This document helps AI agents understand and apply MongoDB's IPA guidelines when assisting developers with API design, code reviews, and implementation. IPAs represent MongoDB's best practices for API design, covering everything from resource-oriented design to error handling and versioning.
+This document helps AI agents understand and apply MongoDB's IPA guidelines when
+assisting developers with API design, code reviews, and implementation. IPAs
+represent MongoDB's best practices for API design, covering everything from
+resource-oriented design to error handling and versioning.
 
 ### Target Audience
 
@@ -29,8 +35,11 @@ This document helps AI agents understand and apply MongoDB's IPA guidelines when
 ### How This Fits Into the IPA Ecosystem
 
 - **IPA Documentation** ([ipa/](ipa/)): Conceptual guidelines and best practices
-- **IPA Validation** ([docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)): Automated Spectral-based linting rules
-- **This Document**: Bridge between conceptual guidelines and practical application by AI agents
+- **IPA Validation**
+  ([docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)):
+  Automated Spectral-based linting rules
+- **This Document**: Bridge between conceptual guidelines and practical
+  application by AI agents
 
 ## Understanding the IPA Framework
 
@@ -39,7 +48,9 @@ This document helps AI agents understand and apply MongoDB's IPA guidelines when
 IPAs are organized into three categories by number:
 
 #### Meta-IPAs (1-99)
+
 Guidelines about the IPA system itself:
+
 - **IPA-1**: Improvement Proposal for APIs (what IPAs are)
 - **IPA-2**: IPA Numbering (how IPAs are numbered)
 - **IPA-3**: IPA Style and Guidance (how to write IPAs)
@@ -47,7 +58,9 @@ Guidelines about the IPA system itself:
 - **IPA-5**: Documenting Exceptions to IPAs (how to handle exceptions)
 
 #### General API Guidance (100-899)
+
 Core API design principles and patterns:
+
 - **IPA-100**: Language (American English)
 - **IPA-101**: Resource-Oriented Design
 - **IPA-102**: Resource Identifiers
@@ -64,7 +77,9 @@ Core API design principles and patterns:
 - **IPA-128**: Stability Levels
 
 #### SDK and Client Integrations (900-999)
+
 Guidelines for SDK development and client libraries:
+
 - **IPA-900**: SDK and Client Integrations
 
 ### IPA States
@@ -76,7 +91,8 @@ Each IPA has a state indicating its maturity and adoption status:
 - **Deprecated**: Being phased out; avoid in new designs
 - **Retired**: No longer applicable
 
-**Agent Guidance**: Prioritize IPAs in "Adopt" state. Mention "Experimental" IPAs as optional considerations. Warn about "Deprecated" or "Retired" IPAs.
+**Agent Guidance**: Prioritize IPAs in "Adopt" state. Mention "Experimental"
+IPAs as optional considerations. Warn about "Deprecated" or "Retired" IPAs.
 
 ### RFC 2119 Keywords
 
@@ -89,6 +105,7 @@ IPAs use RFC 2119 keywords to indicate requirement levels:
 - **MAY** / **OPTIONAL**: Truly optional
 
 **Agent Guidance**:
+
 - Treat MUST requirements as non-negotiable
 - Present SHOULD requirements as strong recommendations with rationale
 - Offer MAY suggestions as optional improvements
@@ -96,11 +113,13 @@ IPAs use RFC 2119 keywords to indicate requirement levels:
 ### IPA Cross-References
 
 IPAs frequently reference each other. For example:
+
 - IPA-104 (GET) references IPA-114 (Errors) for error handling
 - IPA-105 (LIST) references IPA-110 (Pagination) for result pagination
 - IPA-120 (Versioning) references IPA-116 (Backwards Compatibility)
 
-**Agent Guidance**: When citing an IPA, check for related IPAs and mention them when relevant.
+**Agent Guidance**: When citing an IPA, check for related IPAs and mention them
+when relevant.
 
 ## How AI Agents Should Apply IPAs
 
@@ -109,16 +128,19 @@ IPAs frequently reference each other. For example:
 Follow this systematic approach:
 
 #### 1. Resource-Oriented Design (IPA-101)
+
 - Verify the API is organized around resources (nouns), not actions (verbs)
 - Check that resources have clear, hierarchical relationships
 - Ensure resource names are plural (e.g., `/clusters`, not `/cluster`)
 
 #### 2. Resource Identifiers (IPA-102)
+
 - Validate identifier format and uniqueness
 - Check for consistent identifier patterns across resources
 - Verify identifiers are immutable and opaque
 
 #### 3. Standard Methods (IPA-103-108)
+
 - **GET (IPA-104)**: Retrieve a single resource
 - **LIST (IPA-105)**: Retrieve a collection of resources
 - **CREATE (IPA-106)**: Create a new resource
@@ -126,27 +148,32 @@ Follow this systematic approach:
 - **DELETE (IPA-108)**: Remove a resource
 
 For each method, verify:
+
 - Correct HTTP verb usage
 - Proper URL structure
 - Appropriate request/response schemas
 - Error handling per IPA-114
 
 #### 4. Pagination (IPA-110)
+
 - Check LIST operations include pagination support
 - Verify pagination parameters follow IPA standards
 - Ensure consistent pagination patterns across endpoints
 
 #### 5. Error Handling (IPA-114)
+
 - Validate error response structure
 - Check for appropriate HTTP status codes
 - Ensure error messages are clear and actionable
 
 #### 6. Backwards Compatibility (IPA-116)
+
 - Review changes for breaking vs. non-breaking modifications
 - Verify deprecation strategies for breaking changes
 - Check version compatibility considerations
 
 #### 7. Versioning (IPA-120)
+
 - Validate versioning strategy
 - Check version format and placement
 - Ensure version migration paths are clear
@@ -154,20 +181,28 @@ For each method, verify:
 ### When Suggesting API Changes
 
 #### Always Cite Specific IPAs
-When recommending changes, reference the specific IPA that supports your recommendation:
 
-✅ **Good**: "According to IPA-101 (Resource-Oriented Design), this endpoint should use `/clusters/{clusterId}` instead of `/getCluster?id={clusterId}` to follow resource-oriented patterns."
+When recommending changes, reference the specific IPA that supports your
+recommendation:
+
+✅ **Good**: "According to IPA-101 (Resource-Oriented Design), this endpoint
+should use `/clusters/{clusterId}` instead of `/getCluster?id={clusterId}` to
+follow resource-oriented patterns."
 
 ❌ **Bad**: "You should use REST patterns here."
 
 #### Consider Context and Trade-offs
-Not every situation is black and white. When IPAs conflict or exceptions are needed:
+
+Not every situation is black and white. When IPAs conflict or exceptions are
+needed:
+
 - Acknowledge the trade-offs
 - Explain why the IPA guideline exists
 - Suggest the best path forward given constraints
 - Document exceptions per IPA-5
 
 #### Provide Actionable Recommendations
+
 Include concrete examples:
 
 ```yaml
@@ -198,14 +233,16 @@ When multiple IPAs apply, prioritize in this order:
 
 ### When to Suggest Exceptions
 
-Exceptions to IPAs should be rare but are sometimes necessary. Suggest an exception when:
+Exceptions to IPAs should be rare but are sometimes necessary. Suggest an
+exception when:
 
 1. **Legacy compatibility** requires deviation
 2. **Technical constraints** make compliance impossible
 3. **Domain-specific requirements** conflict with general guidance
 4. **Performance considerations** necessitate a different approach
 
-Always document exceptions using the format from IPA-5 (see [IPA Validation & Linting](#ipa-validation--linting) section).
+Always document exceptions using the format from IPA-5 (see
+[IPA Validation & Linting](#ipa-validation--linting) section).
 
 ## Referencing IPAs in Recommendations
 
@@ -218,9 +255,13 @@ According to IPA-XXX ([Title]), [specific guidance].
 ```
 
 **Examples**:
-- "According to IPA-101 (Resource-Oriented Design), APIs should be organized around resources (nouns) rather than actions (verbs)."
-- "Per IPA-110 (Pagination), LIST operations must support pagination using the `pageToken` parameter."
-- "Following IPA-114 (Errors), error responses should include a `code`, `message`, and `details` field."
+
+- "According to IPA-101 (Resource-Oriented Design), APIs should be organized
+  around resources (nouns) rather than actions (verbs)."
+- "Per IPA-110 (Pagination), LIST operations must support pagination using the
+  `pageToken` parameter."
+- "Following IPA-114 (Errors), error responses should include a `code`,
+  `message`, and `details` field."
 
 ### Linking to IPAs
 
@@ -229,7 +270,8 @@ When referencing IPAs in written recommendations, use relative links:
 - General IPAs: `[IPA-XXX](ipa/general/0XXX.md)`
 - SDK IPAs: `[IPA-9XX](ipa/sdks/09XX.md)`
 
-**Example**: "See [IPA-101](ipa/general/0101.md) for details on resource-oriented design."
+**Example**: "See [IPA-101](ipa/general/0101.md) for details on
+resource-oriented design."
 
 ### Handling Multiple Applicable IPAs
 
@@ -239,12 +281,12 @@ When multiple IPAs apply to a situation:
 2. **Explain how they relate** to each other
 3. **Provide integrated guidance** that satisfies all applicable IPAs
 
-**Example**:
-"This LIST endpoint should follow several IPAs:
+**Example**: "This LIST endpoint should follow several IPAs:
+
 - **IPA-105** (LIST): Use GET method with collection URL
 - **IPA-110** (Pagination): Include `pageToken` and `pageSize` parameters
-- **IPA-114** (Errors): Return structured errors for invalid pagination parameters"
-
+- **IPA-114** (Errors): Return structured errors for invalid pagination
+  parameters"
 
 ## IPA Validation & Linting
 
@@ -252,14 +294,20 @@ When multiple IPAs apply to a situation:
 
 MongoDB provides two complementary approaches to IPA compliance:
 
-1. **Conceptual Guidelines** (this repository): High-level principles and best practices documented in the `ipa/` folder
-2. **Automated Linting Rules** (mongodb/openapi repository): Spectral-based rules that automatically validate OpenAPI specifications
+1. **Conceptual Guidelines** (this repository): High-level principles and best
+   practices documented in the `ipa/` folder
+2. **Automated Linting Rules** (mongodb/openapi repository): Spectral-based
+   rules that automatically validate OpenAPI specifications
 
 **Key Points for Agents**:
+
 - Not all IPAs can be automatically validated (some require human judgment)
 - Linting rules are named: `xgen-IPA-<number>-<rule-name>`
-- Automated validation catches common issues but doesn't replace thoughtful design review
-- See [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md) for complete linting documentation
+- Automated validation catches common issues but doesn't replace thoughtful
+  design review
+- See
+  [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)
+  for complete linting documentation
 
 ### Using Spectral for IPA Validation
 
@@ -291,9 +339,11 @@ When reviewing API designs, agents should:
 1. **Suggest running Spectral validation** to catch automated issues
 2. **Interpret Spectral errors** and relate them back to IPA guidelines
 3. **Provide context** for why the linting rule exists
-4. **Suggest fixes** that address both the linting error and the underlying IPA principle
+4. **Suggest fixes** that address both the linting error and the underlying IPA
+   principle
 
 **Example Agent Response**:
+
 ```
 I see Spectral is reporting a `xgen-IPA-101-resource-oriented-design` error. This relates to
 IPA-101 (Resource-Oriented Design), which requires APIs to be organized around resources
@@ -307,7 +357,8 @@ This change makes the API more intuitive and consistent with REST principles.
 
 ### Documenting IPA Exceptions
 
-When an API must deviate from IPA guidelines, document the exception using the `x-xgen-IPA-exception` extension per IPA-5:
+When an API must deviate from IPA guidelines, document the exception using the
+`x-xgen-IPA-exception` extension per IPA-5:
 
 #### Exception Format
 
@@ -325,6 +376,7 @@ paths:
 #### When Agents Should Suggest Exceptions
 
 Suggest documenting an exception when:
+
 - The developer explicitly states a constraint that prevents IPA compliance
 - Legacy compatibility is mentioned as a requirement
 - Technical limitations are identified that make compliance impractical
@@ -344,11 +396,16 @@ x-xgen-IPA-exception:
 ### Linting Rule Coverage
 
 For a complete list of implemented linting rules, see:
-- **Ruleset Documentation**: https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme
-- **Local Copy**: [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)
+
+- **Ruleset Documentation**:
+  https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme
+- **Local Copy**:
+  [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)
 
 Common linting rules include:
-- `xgen-IPA-101-resource-oriented-design`: Validates resource-oriented URL patterns
+
+- `xgen-IPA-101-resource-oriented-design`: Validates resource-oriented URL
+  patterns
 - `xgen-IPA-104-get-method`: Validates GET operation structure
 - `xgen-IPA-105-list-method`: Validates LIST operation structure
 - `xgen-IPA-110-pagination`: Validates pagination parameters
@@ -373,7 +430,9 @@ api-designs/
 ### What to Include in API Design Documents
 
 #### openapi.yaml (Required)
+
 The OpenAPI 3.x specification following IPA guidelines. Include:
+
 - Complete resource definitions
 - All standard methods (GET, LIST, CREATE, UPDATE, DELETE)
 - Custom methods if needed
@@ -382,39 +441,48 @@ The OpenAPI 3.x specification following IPA guidelines. Include:
 - Proper versioning in the URL path
 
 #### design-notes.md (Recommended)
+
 Document design decisions and rationale:
 
 ```markdown
 # API Design Notes: [Project Name]
 
 ## Problem Statement
+
 [What problem does this API solve?]
 
 ## Design Approach
+
 [Why did you choose this design?]
 
 ## Key Decisions
+
 1. **Resource Model**: [How resources are organized]
 2. **Naming Conventions**: [Naming choices and rationale]
 3. **Versioning Strategy**: [How versioning is handled]
 
 ## Alternatives Considered
+
 [What other approaches were evaluated and why were they rejected?]
 
 ## Trade-offs
+
 [What compromises were made and why?]
 
 ## IPA Compliance
+
 [How this design follows IPA guidelines]
 ```
 
 #### ipa-compliance.md (Recommended)
+
 Track compliance with relevant IPAs:
 
 ```markdown
 # IPA Compliance Checklist: [Project Name]
 
 ## Core IPAs
+
 - [x] IPA-101: Resource-Oriented Design - Resources use plural nouns
 - [x] IPA-102: Resource Identifiers - Using opaque, immutable IDs
 - [x] IPA-103: Methods - Standard methods implemented
@@ -429,24 +497,29 @@ Track compliance with relevant IPAs:
 - [x] IPA-120: Versioning - Using /v1/ in URL path
 
 ## Exceptions
-### IPA-105: LIST Method
-**Reason**: Legacy pagination uses offset/limit instead of pageToken
-**Mitigation**: Documented in API, will migrate to pageToken in v2
-**Timeline**: Q2 2024
-```
 
+### IPA-105: LIST Method
+
+**Reason**: Legacy pagination uses offset/limit instead of pageToken
+**Mitigation**: Documented in API, will migrate to pageToken in v2 **Timeline**:
+Q2 2024
+```
 
 ### How Agents Should Reference API Design Files
 
 When working with API designs in the `api-designs/` folder:
 
-1. **Check for existing designs first**: Before creating a new design, search for existing work
-2. **Load all relevant files**: Read openapi.yaml, design-notes.md, and ipa-compliance.md together
+1. **Check for existing designs first**: Before creating a new design, search
+   for existing work
+2. **Load all relevant files**: Read openapi.yaml, design-notes.md, and
+   ipa-compliance.md together
 3. **Suggest improvements**: Based on IPA guidelines, recommend specific changes
-4. **Update documentation**: When modifying openapi.yaml, also update design-notes.md and ipa-compliance.md
+4. **Update documentation**: When modifying openapi.yaml, also update
+   design-notes.md and ipa-compliance.md
 5. **Run validation**: Suggest running Spectral validation after changes
 
 **Example Agent Workflow**:
+
 ```
 User: "Review my cluster API design"
 
@@ -462,11 +535,13 @@ Agent:
 
 ## Example Workflows & Prompts
 
-This section provides concrete examples of how developers should interact with AI agents when working with IPA guidelines.
+This section provides concrete examples of how developers should interact with
+AI agents when working with IPA guidelines.
 
 ### Workflow 1: Reviewing an Existing API Design
 
 **User Prompt**:
+
 ```
 Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
 ```
@@ -474,6 +549,7 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
 **Agent Response Pattern**:
 
 1. **Load the OpenAPI specification**
+
    ```
    I'll review your cluster API design against IPA guidelines.
    ```
@@ -488,6 +564,7 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
    - IPA-120: Versioning
 
 3. **Provide specific feedback with IPA citations**
+
    ```
    ✅ IPA-101 (Resource-Oriented Design): Good! Using /api/v1/clusters/{clusterId}
 
@@ -500,6 +577,7 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
    ```
 
 4. **Suggest improvements with code examples**
+
    ```yaml
    # Add to your LIST operation:
    parameters:
@@ -517,6 +595,7 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
    ```
 
 5. **Note any required exceptions**
+
    ```
    If you need to deviate from IPA-110 for legacy reasons, document it:
 
@@ -529,6 +608,7 @@ Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
 ### Workflow 2: Designing a New API Resource
 
 **User Prompt**:
+
 ```
 Help me design a new API for managing database backups following IPA guidelines
 ```
@@ -536,6 +616,7 @@ Help me design a new API for managing database backups following IPA guidelines
 **Agent Response Pattern**:
 
 1. **Start with resource-oriented design (IPA-101)**
+
    ```
    Let's design a backup API following IPA guidelines. First, let's identify the resource:
 
@@ -544,6 +625,7 @@ Help me design a new API for managing database backups following IPA guidelines
    ```
 
 2. **Define resource identifiers (IPA-102)**
+
    ```
    Backup identifiers should be:
    - Opaque (not expose internal structure)
@@ -554,6 +636,7 @@ Help me design a new API for managing database backups following IPA guidelines
    ```
 
 3. **Plan standard methods (IPA-103-108)**
+
    ```
    Standard methods for backups:
    - GET /api/v1/backups/{backupId} - Retrieve a backup
@@ -564,6 +647,7 @@ Help me design a new API for managing database backups following IPA guidelines
    ```
 
 4. **Consider pagination (IPA-110)**
+
    ```
    For the LIST operation, include pagination:
 
@@ -577,6 +661,7 @@ Help me design a new API for managing database backups following IPA guidelines
    ```
 
 5. **Plan error responses (IPA-114)**
+
    ```
    Error response structure:
    {
@@ -591,6 +676,7 @@ Help me design a new API for managing database backups following IPA guidelines
    ```
 
 6. **Create OpenAPI spec in api-designs/backups/**
+
    ```
    I'll create the following files:
    - api-designs/backups/openapi.yaml
@@ -607,6 +693,7 @@ Help me design a new API for managing database backups following IPA guidelines
 ### Workflow 3: Validating IPA Compliance for a Specific IPA
 
 **User Prompt**:
+
 ```
 Check if my API follows IPA-104 (GET method) requirements
 ```
@@ -614,6 +701,7 @@ Check if my API follows IPA-104 (GET method) requirements
 **Agent Response Pattern**:
 
 1. **Reference IPA-104 specific requirements**
+
    ```
    I'll check your API against IPA-104 (GET) requirements:
 
@@ -627,21 +715,25 @@ Check if my API follows IPA-104 (GET method) requirements
    ```
 
 2. **Check operation ID naming**
+
    ```
    ✅ Operation ID: "getCluster" (camelCase, starts with "get")
    ```
 
 3. **Verify HTTP method**
+
    ```
    ✅ Using HTTP GET method
    ```
 
 4. **Ensure no request body**
+
    ```
    ✅ No request body defined
    ```
 
 5. **Check response schema structure**
+
    ```
    ✅ Returns single cluster object
 
@@ -654,6 +746,7 @@ Check if my API follows IPA-104 (GET method) requirements
    ```
 
 6. **Validate error handling references IPA-114**
+
    ```
    ⚠️  Missing 404 error response for when cluster is not found.
 
@@ -671,6 +764,7 @@ Check if my API follows IPA-104 (GET method) requirements
 ### Workflow 4: Documenting IPA Exceptions
 
 **User Prompt**:
+
 ```
 I need to deviate from IPA-105 for legacy reasons. How should I document this?
 ```
@@ -678,12 +772,14 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
 **Agent Response Pattern**:
 
 1. **Reference IPA-5 (Documenting Exceptions)**
+
    ```
    According to IPA-5 (Documenting Exceptions), you should document
    deviations using the x-xgen-IPA-exception extension.
    ```
 
 2. **Provide x-xgen-IPA-exception format**
+
    ```yaml
    paths:
      /api/v1/clusters:
@@ -698,6 +794,7 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
    ```
 
 3. **Help write clear justification**
+
    ```
    Your exception documentation should include:
    - **Reason**: Why the exception is necessary
@@ -707,6 +804,7 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
    ```
 
 4. **Suggest mitigation strategies**
+
    ```
    Mitigation strategies for pagination exception:
    1. Document the limitation clearly in API documentation
@@ -716,6 +814,7 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
    ```
 
 5. **Update design documentation**
+
    ```
    Also update api-designs/clusters/ipa-compliance.md:
 
@@ -729,6 +828,7 @@ I need to deviate from IPA-105 for legacy reasons. How should I document this?
 ### Workflow 5: Creating a Custom Method
 
 **User Prompt**:
+
 ```
 I need to add a "restart cluster" operation. How should I design this following IPA guidelines?
 ```
@@ -736,12 +836,14 @@ I need to add a "restart cluster" operation. How should I design this following 
 **Agent Response Pattern**:
 
 1. **Reference IPA-109 (Custom Methods)**
+
    ```
    This operation doesn't fit standard methods (GET, LIST, CREATE, UPDATE, DELETE),
    so we'll use a custom method per IPA-109 (Custom Methods).
    ```
 
 2. **Recommend custom method pattern**
+
    ```
    According to IPA-109, custom methods should:
    - Use POST HTTP method
@@ -753,6 +855,7 @@ I need to add a "restart cluster" operation. How should I design this following 
    ```
 
 3. **Provide complete example**
+
    ```yaml
    paths:
      /api/v1/clusters/{clusterId}:restart:
@@ -775,18 +878,18 @@ I need to add a "restart cluster" operation. How should I design this following 
                      type: boolean
                      description: Force restart even if cluster is busy
          responses:
-           '200':
+           "200":
              description: Cluster restart initiated
              content:
                application/json:
                  schema:
-                   $ref: '#/components/schemas/Cluster'
-           '404':
+                   $ref: "#/components/schemas/Cluster"
+           "404":
              description: Cluster not found
              content:
                application/json:
                  schema:
-                   $ref: '#/components/schemas/Error'
+                   $ref: "#/components/schemas/Error"
    ```
 
 4. **Explain rationale**
@@ -799,7 +902,6 @@ I need to add a "restart cluster" operation. How should I design this following 
    - Includes proper error handling (IPA-114)
    ```
 
-
 ## Quick Reference
 
 ### Most Commonly Referenced IPAs
@@ -807,6 +909,7 @@ I need to add a "restart cluster" operation. How should I design this following 
 When reviewing or designing APIs, these IPAs are most frequently applicable:
 
 #### Core Design Principles
+
 - **[IPA-101](ipa/general/0101.md): Resource-Oriented Design**
   - APIs organized around resources (nouns), not actions (verbs)
   - Use plural resource names: `/clusters`, not `/cluster`
@@ -822,6 +925,7 @@ When reviewing or designing APIs, these IPAs are most frequently applicable:
   - Consistent method semantics across resources
 
 #### Standard Methods
+
 - **[IPA-104](ipa/general/0104.md): GET**
   - Retrieve a single resource
   - HTTP GET, no request body
@@ -853,6 +957,7 @@ When reviewing or designing APIs, these IPAs are most frequently applicable:
   - Example: `POST /api/v1/clusters/{clusterId}:restart`
 
 #### Common Patterns
+
 - **[IPA-110](ipa/general/0110.md): Pagination**
   - Use `pageToken` and `pageSize` parameters
   - Return `nextPageToken` in response
@@ -889,6 +994,7 @@ When reviewing or designing APIs, these IPAs are most frequently applicable:
   - Human-readable messages
 
 #### Meta-IPAs
+
 - **[IPA-5](ipa/general/0005.md): Documenting Exceptions**
   - How to document IPA exceptions
   - `x-xgen-IPA-exception` format
@@ -896,26 +1002,30 @@ When reviewing or designing APIs, these IPAs are most frequently applicable:
 
 ### Key Links
 
-| Resource | Link |
-|----------|------|
-| **IPA Documentation** | https://mongodb.github.io/ipa/ |
+| Resource                      | Link                                                                             |
+| ----------------------------- | -------------------------------------------------------------------------------- |
+| **IPA Documentation**         | https://mongodb.github.io/ipa/                                                   |
 | **IPA Validation (Spectral)** | [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md) |
-| **Spectral Ruleset** | https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme |
-| **API Designs Folder** | [api-designs/](api-designs/) |
-| **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| **Spectral Ruleset**          | https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme  |
+| **API Designs Folder**        | [api-designs/](api-designs/)                                                     |
+| **Contributing**              | [CONTRIBUTING.md](CONTRIBUTING.md)                                               |
 
 ### Common IPA Patterns
 
 #### Resource URL Pattern
+
 ```
 /api/v{majorVersion}/{resourcePlural}/{resourceId}
 ```
+
 Examples:
+
 - `/api/v1/clusters/cluster-123`
 - `/api/v1/backups/backup-456`
 - `/api/v2/databases/db-789`
 
 #### Standard Method URLs
+
 ```
 GET    /api/v1/clusters/{clusterId}      # Get single resource
 GET    /api/v1/clusters                  # List resources
@@ -925,6 +1035,7 @@ DELETE /api/v1/clusters/{clusterId}      # Delete resource
 ```
 
 #### Custom Method URL
+
 ```
 POST /api/v1/clusters/{clusterId}:restart
 POST /api/v1/backups/{backupId}:restore
@@ -932,11 +1043,13 @@ POST /api/v1/databases/{databaseId}:export
 ```
 
 #### Pagination Parameters
+
 ```
 GET /api/v1/clusters?pageToken={token}&pageSize=20
 ```
 
 Response:
+
 ```json
 {
   "clusters": [...],
@@ -945,6 +1058,7 @@ Response:
 ```
 
 #### Error Response Structure
+
 ```json
 {
   "error": {
@@ -963,6 +1077,7 @@ Response:
 ### 1. Always Read the Full IPA Before Citing
 
 Don't rely on IPA titles alone. Read the complete IPA document to understand:
+
 - The specific requirements (MUST, SHOULD, MAY)
 - The rationale behind the guideline
 - Examples and counter-examples
@@ -971,24 +1086,30 @@ Don't rely on IPA titles alone. Read the complete IPA document to understand:
 ### 2. Consider Context and Trade-offs
 
 Not every situation is straightforward. When providing guidance:
-- **Acknowledge constraints**: Legacy systems, performance requirements, domain-specific needs
+
+- **Acknowledge constraints**: Legacy systems, performance requirements,
+  domain-specific needs
 - **Explain trade-offs**: What are the pros and cons of different approaches?
-- **Provide options**: When multiple valid approaches exist, present them with rationale
+- **Provide options**: When multiple valid approaches exist, present them with
+  rationale
 - **Be pragmatic**: Perfect IPA compliance isn't always possible or necessary
 
 ### 3. Provide Actionable, Specific Recommendations
 
 Vague advice isn't helpful. Instead:
 
-❌ **Bad**: "This doesn't follow REST principles"
-✅ **Good**: "According to IPA-101, use `/api/v1/clusters/{clusterId}` instead of `/getCluster?id={clusterId}`"
+❌ **Bad**: "This doesn't follow REST principles" ✅ **Good**: "According to
+IPA-101, use `/api/v1/clusters/{clusterId}` instead of
+`/getCluster?id={clusterId}`"
 
-❌ **Bad**: "You need better error handling"
-✅ **Good**: "Per IPA-114, add a structured error response with `code`, `message`, and `detail` fields. Here's an example: [code snippet]"
+❌ **Bad**: "You need better error handling" ✅ **Good**: "Per IPA-114, add a
+structured error response with `code`, `message`, and `detail` fields. Here's an
+example: [code snippet]"
 
 ### 4. Include Code Examples
 
 Show, don't just tell. Provide:
+
 - **Before/after comparisons**: Show the current state and the improved version
 - **Complete examples**: Include enough context to be useful
 - **Proper formatting**: Use YAML/JSON syntax highlighting
@@ -997,13 +1118,16 @@ Show, don't just tell. Provide:
 ### 5. Link Related IPAs
 
 IPAs often reference each other. When citing one IPA:
+
 - **Mention related IPAs**: "IPA-105 (LIST) works with IPA-110 (Pagination)"
 - **Explain relationships**: How do these IPAs work together?
-- **Provide integrated guidance**: Show how to satisfy multiple IPAs simultaneously
+- **Provide integrated guidance**: Show how to satisfy multiple IPAs
+  simultaneously
 
 ### 6. Respect IPA States
 
 Pay attention to IPA maturity:
+
 - **Adopt**: Recommend strongly, treat as standard
 - **Experimental**: Mention as optional, note experimental status
 - **Deprecated**: Warn against use, suggest alternatives
@@ -1012,7 +1136,9 @@ Pay attention to IPA maturity:
 ### 7. Suggest Validation
 
 After providing recommendations:
-- **Suggest Spectral validation**: "Run `npx spectral lint openapi.yaml` to check for issues"
+
+- **Suggest Spectral validation**: "Run `npx spectral lint openapi.yaml` to
+  check for issues"
 - **Explain validation results**: Help interpret linting errors
 - **Provide fixes**: Show how to address validation failures
 - **Document exceptions**: Help write proper exception documentation
@@ -1020,12 +1146,14 @@ After providing recommendations:
 ### 8. Help Developers Understand "Why"
 
 Don't just enforce rules. Explain:
+
 - **The purpose**: Why does this IPA exist?
 - **The benefits**: What problems does it solve?
 - **The consequences**: What happens if you don't follow it?
 - **The alternatives**: Are there other valid approaches?
 
 **Example**:
+
 ```
 IPA-110 (Pagination) requires using pageToken instead of offset/limit because:
 - Tokens are stable even when data changes
@@ -1040,22 +1168,29 @@ and explain the trade-offs to API consumers.
 ### 9. Be Aware of IPA Evolution
 
 IPAs evolve over time:
+
 - **Check IPA state**: Is this still "Adopt" or has it been deprecated?
 - **Note recent changes**: Has the IPA been updated recently?
-- **Suggest updates**: "This design follows IPA-XXX v1, but v2 has new recommendations"
+- **Suggest updates**: "This design follows IPA-XXX v1, but v2 has new
+  recommendations"
 - **Stay current**: Periodically review IPA documentation for updates
 
 ### 10. Encourage Consistency
 
 Consistency is key to good API design:
-- **Check existing patterns**: "Your other endpoints use pageToken; this one should too"
+
+- **Check existing patterns**: "Your other endpoints use pageToken; this one
+  should too"
 - **Suggest standardization**: "Let's align this with your clusters API design"
-- **Reference internal examples**: "This follows the same pattern as your backups API"
-- **Build on precedent**: "Since you're already using IPA-101 elsewhere, apply it here too"
+- **Reference internal examples**: "This follows the same pattern as your
+  backups API"
+- **Build on precedent**: "Since you're already using IPA-101 elsewhere, apply
+  it here too"
 
 ### 11. Document Decisions
 
 Help developers capture their reasoning:
+
 - **Suggest creating design-notes.md**: Document why decisions were made
 - **Update ipa-compliance.md**: Track which IPAs are followed
 - **Record exceptions**: Use proper exception documentation format
@@ -1064,6 +1199,7 @@ Help developers capture their reasoning:
 ### 12. Balance Perfectionism with Pragmatism
 
 Perfect IPA compliance isn't always achievable or necessary:
+
 - **Prioritize**: Focus on MUST requirements first
 - **Be flexible**: SHOULD requirements may have valid exceptions
 - **Consider ROI**: Is the effort to fix this issue worth the benefit?
@@ -1073,19 +1209,19 @@ Perfect IPA compliance isn't always achievable or necessary:
 
 ## Conclusion
 
-This document provides comprehensive guidance for AI agents working with MongoDB's IPA guidelines. By following these practices, agents can:
+This document provides comprehensive guidance for AI agents working with
+MongoDB's IPA guidelines. By following these practices, agents can:
 
 - **Provide valuable, actionable feedback** on API designs
 - **Help developers understand and apply** IPA principles
 - **Balance idealism with pragmatism** in real-world constraints
 - **Improve API consistency and quality** across MongoDB's platform
 
-For questions or suggestions about these guidelines, please open an issue or contribute to this document following the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
+For questions or suggestions about these guidelines, please open an issue or
+contribute to this document following the [CONTRIBUTING.md](CONTRIBUTING.md)
+guidelines.
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2024-01-15
-**Maintained By**: MongoDB API Experience Team
-
-
+**Document Version**: 1.0 **Last Updated**: 2024-01-15 **Maintained By**:
+MongoDB API Experience Team

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,1091 @@
+# AI Agent Guidelines for MongoDB IPA
+
+This document provides guidance for AI agents (Augment, Claude, GitHub Copilot, etc.) and developers using them to effectively apply MongoDB's Improvement Proposal for APIs (IPA) guidelines when designing, reviewing, and implementing APIs.
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Understanding the IPA Framework](#understanding-the-ipa-framework)
+- [How AI Agents Should Apply IPAs](#how-ai-agents-should-apply-ipas)
+- [Referencing IPAs in Recommendations](#referencing-ipas-in-recommendations)
+- [IPA Validation & Linting](#ipa-validation--linting)
+- [Working with API Designs](#working-with-api-designs)
+- [Example Workflows & Prompts](#example-workflows--prompts)
+- [Quick Reference](#quick-reference)
+- [Best Practices for AI Agents](#best-practices-for-ai-agents)
+
+## Introduction
+
+### Purpose
+
+This document helps AI agents understand and apply MongoDB's IPA guidelines when assisting developers with API design, code reviews, and implementation. IPAs represent MongoDB's best practices for API design, covering everything from resource-oriented design to error handling and versioning.
+
+### Target Audience
+
+- **AI Agents**: Augment, Claude, GitHub Copilot, and other AI coding assistants
+- **Developers**: Engineers using AI agents to design or review APIs
+- **API Reviewers**: Team members evaluating API designs for IPA compliance
+
+### How This Fits Into the IPA Ecosystem
+
+- **IPA Documentation** ([ipa/](ipa/)): Conceptual guidelines and best practices
+- **IPA Validation** ([docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)): Automated Spectral-based linting rules
+- **This Document**: Bridge between conceptual guidelines and practical application by AI agents
+
+## Understanding the IPA Framework
+
+### IPA Organization
+
+IPAs are organized into three categories by number:
+
+#### Meta-IPAs (1-99)
+Guidelines about the IPA system itself:
+- **IPA-1**: Improvement Proposal for APIs (what IPAs are)
+- **IPA-2**: IPA Numbering (how IPAs are numbered)
+- **IPA-3**: IPA Style and Guidance (how to write IPAs)
+- **IPA-4**: Glossary (terminology definitions)
+- **IPA-5**: Documenting Exceptions to IPAs (how to handle exceptions)
+
+#### General API Guidance (100-899)
+Core API design principles and patterns:
+- **IPA-100**: Language (American English)
+- **IPA-101**: Resource-Oriented Design
+- **IPA-102**: Resource Identifiers
+- **IPA-103-108**: Standard Methods (GET, LIST, CREATE, UPDATE, DELETE)
+- **IPA-109**: Custom Methods
+- **IPA-110**: Pagination
+- **IPA-114**: Errors
+- **IPA-116**: Backwards Compatibility
+- **IPA-118**: Extensible by Default
+- **IPA-120**: Versioning
+- **IPA-121**: Datetime
+- **IPA-122**: Standard Codes
+- **IPA-127**: Declarative-Friendly
+- **IPA-128**: Stability Levels
+
+#### SDK and Client Integrations (900-999)
+Guidelines for SDK development and client libraries:
+- **IPA-900**: SDK and Client Integrations
+
+### IPA States
+
+Each IPA has a state indicating its maturity and adoption status:
+
+- **Experimental**: New ideas being explored; use with caution
+- **Adopt**: Approved and recommended for use
+- **Deprecated**: Being phased out; avoid in new designs
+- **Retired**: No longer applicable
+
+**Agent Guidance**: Prioritize IPAs in "Adopt" state. Mention "Experimental" IPAs as optional considerations. Warn about "Deprecated" or "Retired" IPAs.
+
+### RFC 2119 Keywords
+
+IPAs use RFC 2119 keywords to indicate requirement levels:
+
+- **MUST** / **REQUIRED** / **SHALL**: Absolute requirement
+- **MUST NOT** / **SHALL NOT**: Absolute prohibition
+- **SHOULD** / **RECOMMENDED**: Strong recommendation (exceptions may exist)
+- **SHOULD NOT** / **NOT RECOMMENDED**: Strong discouragement
+- **MAY** / **OPTIONAL**: Truly optional
+
+**Agent Guidance**:
+- Treat MUST requirements as non-negotiable
+- Present SHOULD requirements as strong recommendations with rationale
+- Offer MAY suggestions as optional improvements
+
+### IPA Cross-References
+
+IPAs frequently reference each other. For example:
+- IPA-104 (GET) references IPA-114 (Errors) for error handling
+- IPA-105 (LIST) references IPA-110 (Pagination) for result pagination
+- IPA-120 (Versioning) references IPA-116 (Backwards Compatibility)
+
+**Agent Guidance**: When citing an IPA, check for related IPAs and mention them when relevant.
+
+## How AI Agents Should Apply IPAs
+
+### When Reviewing API Designs
+
+Follow this systematic approach:
+
+#### 1. Resource-Oriented Design (IPA-101)
+- Verify the API is organized around resources (nouns), not actions (verbs)
+- Check that resources have clear, hierarchical relationships
+- Ensure resource names are plural (e.g., `/clusters`, not `/cluster`)
+
+#### 2. Resource Identifiers (IPA-102)
+- Validate identifier format and uniqueness
+- Check for consistent identifier patterns across resources
+- Verify identifiers are immutable and opaque
+
+#### 3. Standard Methods (IPA-103-108)
+- **GET (IPA-104)**: Retrieve a single resource
+- **LIST (IPA-105)**: Retrieve a collection of resources
+- **CREATE (IPA-106)**: Create a new resource
+- **UPDATE (IPA-107)**: Modify an existing resource
+- **DELETE (IPA-108)**: Remove a resource
+
+For each method, verify:
+- Correct HTTP verb usage
+- Proper URL structure
+- Appropriate request/response schemas
+- Error handling per IPA-114
+
+#### 4. Pagination (IPA-110)
+- Check LIST operations include pagination support
+- Verify pagination parameters follow IPA standards
+- Ensure consistent pagination patterns across endpoints
+
+#### 5. Error Handling (IPA-114)
+- Validate error response structure
+- Check for appropriate HTTP status codes
+- Ensure error messages are clear and actionable
+
+#### 6. Backwards Compatibility (IPA-116)
+- Review changes for breaking vs. non-breaking modifications
+- Verify deprecation strategies for breaking changes
+- Check version compatibility considerations
+
+#### 7. Versioning (IPA-120)
+- Validate versioning strategy
+- Check version format and placement
+- Ensure version migration paths are clear
+
+### When Suggesting API Changes
+
+#### Always Cite Specific IPAs
+When recommending changes, reference the specific IPA that supports your recommendation:
+
+✅ **Good**: "According to IPA-101 (Resource-Oriented Design), this endpoint should use `/clusters/{clusterId}` instead of `/getCluster?id={clusterId}` to follow resource-oriented patterns."
+
+❌ **Bad**: "You should use REST patterns here."
+
+#### Consider Context and Trade-offs
+Not every situation is black and white. When IPAs conflict or exceptions are needed:
+- Acknowledge the trade-offs
+- Explain why the IPA guideline exists
+- Suggest the best path forward given constraints
+- Document exceptions per IPA-5
+
+#### Provide Actionable Recommendations
+Include concrete examples:
+
+```yaml
+# Before (not IPA-compliant)
+/api/getClusterById:
+  get:
+    parameters:
+      - name: id
+        in: query
+
+# After (IPA-101 compliant)
+/api/v1/clusters/{clusterId}:
+  get:
+    parameters:
+      - name: clusterId
+        in: path
+```
+
+### Prioritization Framework
+
+When multiple IPAs apply, prioritize in this order:
+
+1. **MUST requirements** from Adopt-state IPAs
+2. **SHOULD requirements** from Adopt-state IPAs
+3. **MUST requirements** from Experimental IPAs (with caveats)
+4. **MAY suggestions** from Adopt-state IPAs
+5. **SHOULD requirements** from Experimental IPAs (as optional improvements)
+
+### When to Suggest Exceptions
+
+Exceptions to IPAs should be rare but are sometimes necessary. Suggest an exception when:
+
+1. **Legacy compatibility** requires deviation
+2. **Technical constraints** make compliance impossible
+3. **Domain-specific requirements** conflict with general guidance
+4. **Performance considerations** necessitate a different approach
+
+Always document exceptions using the format from IPA-5 (see [IPA Validation & Linting](#ipa-validation--linting) section).
+
+## Referencing IPAs in Recommendations
+
+### Citation Format
+
+Use this format when citing IPAs:
+
+```
+According to IPA-XXX ([Title]), [specific guidance].
+```
+
+**Examples**:
+- "According to IPA-101 (Resource-Oriented Design), APIs should be organized around resources (nouns) rather than actions (verbs)."
+- "Per IPA-110 (Pagination), LIST operations must support pagination using the `pageToken` parameter."
+- "Following IPA-114 (Errors), error responses should include a `code`, `message`, and `details` field."
+
+### Linking to IPAs
+
+When referencing IPAs in written recommendations, use relative links:
+
+- General IPAs: `[IPA-XXX](ipa/general/0XXX.md)`
+- SDK IPAs: `[IPA-9XX](ipa/sdks/09XX.md)`
+
+**Example**: "See [IPA-101](ipa/general/0101.md) for details on resource-oriented design."
+
+### Handling Multiple Applicable IPAs
+
+When multiple IPAs apply to a situation:
+
+1. **List all relevant IPAs** with brief descriptions
+2. **Explain how they relate** to each other
+3. **Provide integrated guidance** that satisfies all applicable IPAs
+
+**Example**:
+"This LIST endpoint should follow several IPAs:
+- **IPA-105** (LIST): Use GET method with collection URL
+- **IPA-110** (Pagination): Include `pageToken` and `pageSize` parameters
+- **IPA-114** (Errors): Return structured errors for invalid pagination parameters"
+
+
+## IPA Validation & Linting
+
+### Relationship Between Conceptual IPAs and Automated Linting
+
+MongoDB provides two complementary approaches to IPA compliance:
+
+1. **Conceptual Guidelines** (this repository): High-level principles and best practices documented in the `ipa/` folder
+2. **Automated Linting Rules** (mongodb/openapi repository): Spectral-based rules that automatically validate OpenAPI specifications
+
+**Key Points for Agents**:
+- Not all IPAs can be automatically validated (some require human judgment)
+- Linting rules are named: `xgen-IPA-<number>-<rule-name>`
+- Automated validation catches common issues but doesn't replace thoughtful design review
+- See [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md) for complete linting documentation
+
+### Using Spectral for IPA Validation
+
+#### Installation
+
+```bash
+npm install @mongodb-js/ipa-validation-ruleset
+```
+
+#### Configuration
+
+Create a `.spectral.yaml` file in your project:
+
+```yaml
+extends:
+  - "@mongodb/ipa-validation-ruleset"
+```
+
+#### Running Validation
+
+```bash
+npx spectral lint path/to/openapi.yaml --ruleset=.spectral.yaml
+```
+
+#### Integration with AI Agent Workflows
+
+When reviewing API designs, agents should:
+
+1. **Suggest running Spectral validation** to catch automated issues
+2. **Interpret Spectral errors** and relate them back to IPA guidelines
+3. **Provide context** for why the linting rule exists
+4. **Suggest fixes** that address both the linting error and the underlying IPA principle
+
+**Example Agent Response**:
+```
+I see Spectral is reporting a `xgen-IPA-101-resource-oriented-design` error. This relates to
+IPA-101 (Resource-Oriented Design), which requires APIs to be organized around resources
+rather than actions.
+
+Current: POST /api/createCluster
+Suggested: POST /api/v1/clusters
+
+This change makes the API more intuitive and consistent with REST principles.
+```
+
+### Documenting IPA Exceptions
+
+When an API must deviate from IPA guidelines, document the exception using the `x-xgen-IPA-exception` extension per IPA-5:
+
+#### Exception Format
+
+```yaml
+paths:
+  /api/v1/legacy-endpoint:
+    get:
+      x-xgen-IPA-exception:
+        xgen-IPA-101-resource-oriented-design: |
+          This endpoint maintains legacy URL structure for backwards compatibility
+          with existing clients. New endpoints follow IPA-101.
+          Migration plan: Deprecate in v2, remove in v3.
+```
+
+#### When Agents Should Suggest Exceptions
+
+Suggest documenting an exception when:
+- The developer explicitly states a constraint that prevents IPA compliance
+- Legacy compatibility is mentioned as a requirement
+- Technical limitations are identified that make compliance impractical
+- Domain-specific requirements conflict with general IPA guidance
+
+#### Exception Documentation Template
+
+```yaml
+x-xgen-IPA-exception:
+  xgen-IPA-<number>-<rule-name>: |
+    Reason: [Why this exception is necessary]
+    Impact: [What IPA principle is being violated]
+    Mitigation: [How negative impacts are minimized]
+    Timeline: [When/if this will be addressed]
+```
+
+### Linting Rule Coverage
+
+For a complete list of implemented linting rules, see:
+- **Ruleset Documentation**: https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme
+- **Local Copy**: [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md)
+
+Common linting rules include:
+- `xgen-IPA-101-resource-oriented-design`: Validates resource-oriented URL patterns
+- `xgen-IPA-104-get-method`: Validates GET operation structure
+- `xgen-IPA-105-list-method`: Validates LIST operation structure
+- `xgen-IPA-110-pagination`: Validates pagination parameters
+- `xgen-IPA-114-errors`: Validates error response structure
+
+## Working with API Designs
+
+### Recommended Folder Structure
+
+Store API designs in the `api-designs/` folder with this structure:
+
+```
+api-designs/
+├── <project-name>/
+│   ├── openapi.yaml              # OpenAPI 3.x specification
+│   ├── design-notes.md           # Design rationale and decisions
+│   ├── ipa-compliance.md         # IPA compliance checklist
+│   └── .spectral.yaml            # (Optional) Spectral configuration
+└── README.md                     # Usage guide
+```
+
+### What to Include in API Design Documents
+
+#### openapi.yaml (Required)
+The OpenAPI 3.x specification following IPA guidelines. Include:
+- Complete resource definitions
+- All standard methods (GET, LIST, CREATE, UPDATE, DELETE)
+- Custom methods if needed
+- Error responses
+- Pagination parameters for LIST operations
+- Proper versioning in the URL path
+
+#### design-notes.md (Recommended)
+Document design decisions and rationale:
+
+```markdown
+# API Design Notes: [Project Name]
+
+## Problem Statement
+[What problem does this API solve?]
+
+## Design Approach
+[Why did you choose this design?]
+
+## Key Decisions
+1. **Resource Model**: [How resources are organized]
+2. **Naming Conventions**: [Naming choices and rationale]
+3. **Versioning Strategy**: [How versioning is handled]
+
+## Alternatives Considered
+[What other approaches were evaluated and why were they rejected?]
+
+## Trade-offs
+[What compromises were made and why?]
+
+## IPA Compliance
+[How this design follows IPA guidelines]
+```
+
+#### ipa-compliance.md (Recommended)
+Track compliance with relevant IPAs:
+
+```markdown
+# IPA Compliance Checklist: [Project Name]
+
+## Core IPAs
+- [x] IPA-101: Resource-Oriented Design - Resources use plural nouns
+- [x] IPA-102: Resource Identifiers - Using opaque, immutable IDs
+- [x] IPA-103: Methods - Standard methods implemented
+- [x] IPA-104: GET - Retrieves single resource
+- [x] IPA-105: LIST - Returns collection with pagination
+- [ ] IPA-106: CREATE - Not yet implemented
+- [ ] IPA-107: UPDATE - Not yet implemented
+- [ ] IPA-108: DELETE - Not yet implemented
+- [x] IPA-110: Pagination - Using pageToken/pageSize
+- [x] IPA-114: Errors - Structured error responses
+- [x] IPA-116: Backwards Compatibility - No breaking changes
+- [x] IPA-120: Versioning - Using /v1/ in URL path
+
+## Exceptions
+### IPA-105: LIST Method
+**Reason**: Legacy pagination uses offset/limit instead of pageToken
+**Mitigation**: Documented in API, will migrate to pageToken in v2
+**Timeline**: Q2 2024
+```
+
+
+### How Agents Should Reference API Design Files
+
+When working with API designs in the `api-designs/` folder:
+
+1. **Check for existing designs first**: Before creating a new design, search for existing work
+2. **Load all relevant files**: Read openapi.yaml, design-notes.md, and ipa-compliance.md together
+3. **Suggest improvements**: Based on IPA guidelines, recommend specific changes
+4. **Update documentation**: When modifying openapi.yaml, also update design-notes.md and ipa-compliance.md
+5. **Run validation**: Suggest running Spectral validation after changes
+
+**Example Agent Workflow**:
+```
+User: "Review my cluster API design"
+
+Agent:
+1. Loads api-designs/clusters/openapi.yaml
+2. Loads api-designs/clusters/ipa-compliance.md
+3. Reviews against relevant IPAs (101, 102, 103-108, 110, 114, 116, 120)
+4. Identifies issues: "Missing pagination on LIST operation (IPA-110)"
+5. Suggests fix with code example
+6. Recommends updating ipa-compliance.md checklist
+7. Suggests running: npx spectral lint api-designs/clusters/openapi.yaml
+```
+
+## Example Workflows & Prompts
+
+This section provides concrete examples of how developers should interact with AI agents when working with IPA guidelines.
+
+### Workflow 1: Reviewing an Existing API Design
+
+**User Prompt**:
+```
+Review my API design in api-designs/clusters/openapi.yaml against IPA guidelines
+```
+
+**Agent Response Pattern**:
+
+1. **Load the OpenAPI specification**
+   ```
+   I'll review your cluster API design against IPA guidelines.
+   ```
+
+2. **Check against key IPAs**
+   - IPA-101: Resource-Oriented Design
+   - IPA-102: Resource Identifiers
+   - IPA-103-108: Standard Methods
+   - IPA-110: Pagination
+   - IPA-114: Errors
+   - IPA-116: Backwards Compatibility
+   - IPA-120: Versioning
+
+3. **Provide specific feedback with IPA citations**
+   ```
+   ✅ IPA-101 (Resource-Oriented Design): Good! Using /api/v1/clusters/{clusterId}
+
+   ⚠️  IPA-105 (LIST): The LIST operation is missing pagination parameters.
+       According to IPA-110, you should include:
+       - pageToken (string): Token for next page
+       - pageSize (integer): Number of items per page
+
+   ❌ IPA-114 (Errors): Error responses don't include the required 'detail' field.
+   ```
+
+4. **Suggest improvements with code examples**
+   ```yaml
+   # Add to your LIST operation:
+   parameters:
+     - name: pageToken
+       in: query
+       schema:
+         type: string
+       description: Token for retrieving the next page
+     - name: pageSize
+       in: query
+       schema:
+         type: integer
+         default: 20
+         maximum: 100
+   ```
+
+5. **Note any required exceptions**
+   ```
+   If you need to deviate from IPA-110 for legacy reasons, document it:
+
+   x-xgen-IPA-exception:
+     xgen-IPA-110-pagination: |
+       Using offset/limit for backwards compatibility with v1 clients.
+       Will migrate to pageToken in v2.
+   ```
+
+### Workflow 2: Designing a New API Resource
+
+**User Prompt**:
+```
+Help me design a new API for managing database backups following IPA guidelines
+```
+
+**Agent Response Pattern**:
+
+1. **Start with resource-oriented design (IPA-101)**
+   ```
+   Let's design a backup API following IPA guidelines. First, let's identify the resource:
+
+   Resource: "backup" (plural: "backups")
+   URL pattern: /api/v1/backups/{backupId}
+   ```
+
+2. **Define resource identifiers (IPA-102)**
+   ```
+   Backup identifiers should be:
+   - Opaque (not expose internal structure)
+   - Immutable (never change)
+   - Unique across the system
+
+   Example: "backup-a1b2c3d4e5f6"
+   ```
+
+3. **Plan standard methods (IPA-103-108)**
+   ```
+   Standard methods for backups:
+   - GET /api/v1/backups/{backupId} - Retrieve a backup
+   - GET /api/v1/backups - List all backups (with pagination)
+   - POST /api/v1/backups - Create a new backup
+   - PATCH /api/v1/backups/{backupId} - Update backup metadata
+   - DELETE /api/v1/backups/{backupId} - Delete a backup
+   ```
+
+4. **Consider pagination (IPA-110)**
+   ```
+   For the LIST operation, include pagination:
+
+   GET /api/v1/backups?pageToken={token}&pageSize=20
+
+   Response:
+   {
+     "backups": [...],
+     "nextPageToken": "..."
+   }
+   ```
+
+5. **Plan error responses (IPA-114)**
+   ```
+   Error response structure:
+   {
+     "error": {
+       "code": "BACKUP_NOT_FOUND",
+       "message": "Backup 'backup-123' not found",
+       "detail": {
+         "backupId": "backup-123"
+       }
+     }
+   }
+   ```
+
+6. **Create OpenAPI spec in api-designs/backups/**
+   ```
+   I'll create the following files:
+   - api-designs/backups/openapi.yaml
+   - api-designs/backups/design-notes.md
+   - api-designs/backups/ipa-compliance.md
+   ```
+
+7. **Document IPA compliance**
+   ```
+   I'll create an IPA compliance checklist tracking which guidelines
+   are followed and any exceptions needed.
+   ```
+
+### Workflow 3: Validating IPA Compliance for a Specific IPA
+
+**User Prompt**:
+```
+Check if my API follows IPA-104 (GET method) requirements
+```
+
+**Agent Response Pattern**:
+
+1. **Reference IPA-104 specific requirements**
+   ```
+   I'll check your API against IPA-104 (GET) requirements:
+
+   IPA-104 requires:
+   - HTTP GET method
+   - URL pattern: /api/{version}/{resource}/{resourceId}
+   - No request body
+   - Returns single resource representation
+   - Idempotent operation
+   - Error handling per IPA-114
+   ```
+
+2. **Check operation ID naming**
+   ```
+   ✅ Operation ID: "getCluster" (camelCase, starts with "get")
+   ```
+
+3. **Verify HTTP method**
+   ```
+   ✅ Using HTTP GET method
+   ```
+
+4. **Ensure no request body**
+   ```
+   ✅ No request body defined
+   ```
+
+5. **Check response schema structure**
+   ```
+   ✅ Returns single cluster object
+
+   Response schema:
+   {
+     "clusterId": "cluster-123",
+     "name": "production-cluster",
+     "status": "ACTIVE"
+   }
+   ```
+
+6. **Validate error handling references IPA-114**
+   ```
+   ⚠️  Missing 404 error response for when cluster is not found.
+
+   Add this to your GET operation:
+
+   responses:
+     '404':
+       description: Cluster not found
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/Error'
+   ```
+
+### Workflow 4: Documenting IPA Exceptions
+
+**User Prompt**:
+```
+I need to deviate from IPA-105 for legacy reasons. How should I document this?
+```
+
+**Agent Response Pattern**:
+
+1. **Reference IPA-5 (Documenting Exceptions)**
+   ```
+   According to IPA-5 (Documenting Exceptions), you should document
+   deviations using the x-xgen-IPA-exception extension.
+   ```
+
+2. **Provide x-xgen-IPA-exception format**
+   ```yaml
+   paths:
+     /api/v1/clusters:
+       get:
+         x-xgen-IPA-exception:
+           xgen-IPA-105-list-method: |
+             Reason: Maintaining backwards compatibility with v1 API that uses
+                     offset/limit pagination instead of pageToken.
+             Impact: Clients cannot efficiently paginate large result sets.
+             Mitigation: Documented limitation in API docs. V2 will use pageToken.
+             Timeline: Migration to pageToken planned for Q2 2024 in v2 API.
+   ```
+
+3. **Help write clear justification**
+   ```
+   Your exception documentation should include:
+   - **Reason**: Why the exception is necessary
+   - **Impact**: What IPA principle is being violated and consequences
+   - **Mitigation**: How you're minimizing negative impacts
+   - **Timeline**: When/if this will be addressed
+   ```
+
+4. **Suggest mitigation strategies**
+   ```
+   Mitigation strategies for pagination exception:
+   1. Document the limitation clearly in API documentation
+   2. Set reasonable maximum page size (e.g., 100 items)
+   3. Provide guidance on efficient pagination patterns
+   4. Plan migration path to pageToken in next major version
+   ```
+
+5. **Update design documentation**
+   ```
+   Also update api-designs/clusters/ipa-compliance.md:
+
+   ## Exceptions
+   ### IPA-105: LIST Method
+   **Reason**: Legacy pagination uses offset/limit instead of pageToken
+   **Mitigation**: Documented in API, will migrate to pageToken in v2
+   **Timeline**: Q2 2024
+   ```
+
+### Workflow 5: Creating a Custom Method
+
+**User Prompt**:
+```
+I need to add a "restart cluster" operation. How should I design this following IPA guidelines?
+```
+
+**Agent Response Pattern**:
+
+1. **Reference IPA-109 (Custom Methods)**
+   ```
+   This operation doesn't fit standard methods (GET, LIST, CREATE, UPDATE, DELETE),
+   so we'll use a custom method per IPA-109 (Custom Methods).
+   ```
+
+2. **Recommend custom method pattern**
+   ```
+   According to IPA-109, custom methods should:
+   - Use POST HTTP method
+   - Use :verb suffix in URL
+   - Be named with imperative verbs
+
+   Recommended design:
+   POST /api/v1/clusters/{clusterId}:restart
+   ```
+
+3. **Provide complete example**
+   ```yaml
+   paths:
+     /api/v1/clusters/{clusterId}:restart:
+       post:
+         operationId: restartCluster
+         summary: Restart a cluster
+         parameters:
+           - name: clusterId
+             in: path
+             required: true
+             schema:
+               type: string
+         requestBody:
+           content:
+             application/json:
+               schema:
+                 type: object
+                 properties:
+                   force:
+                     type: boolean
+                     description: Force restart even if cluster is busy
+         responses:
+           '200':
+             description: Cluster restart initiated
+             content:
+               application/json:
+                 schema:
+                   $ref: '#/components/schemas/Cluster'
+           '404':
+             description: Cluster not found
+             content:
+               application/json:
+                 schema:
+                   $ref: '#/components/schemas/Error'
+   ```
+
+4. **Explain rationale**
+   ```
+   Why this design follows IPA-109:
+   - Uses POST (custom methods are not idempotent)
+   - Uses :restart suffix (clear action verb)
+   - Applied to specific resource (not collection)
+   - Returns updated resource state
+   - Includes proper error handling (IPA-114)
+   ```
+
+
+## Quick Reference
+
+### Most Commonly Referenced IPAs
+
+When reviewing or designing APIs, these IPAs are most frequently applicable:
+
+#### Core Design Principles
+- **[IPA-101](ipa/general/0101.md): Resource-Oriented Design**
+  - APIs organized around resources (nouns), not actions (verbs)
+  - Use plural resource names: `/clusters`, not `/cluster`
+  - Hierarchical resource relationships
+
+- **[IPA-102](ipa/general/0102.md): Resource Identifiers**
+  - Opaque, immutable, unique identifiers
+  - Consistent identifier patterns across resources
+  - Example: `cluster-a1b2c3d4e5f6`
+
+- **[IPA-103](ipa/general/0103.md): Methods**
+  - Standard methods for common operations
+  - Consistent method semantics across resources
+
+#### Standard Methods
+- **[IPA-104](ipa/general/0104.md): GET**
+  - Retrieve a single resource
+  - HTTP GET, no request body
+  - URL: `/api/v1/{resource}/{resourceId}`
+
+- **[IPA-105](ipa/general/0105.md): LIST**
+  - Retrieve a collection of resources
+  - HTTP GET with pagination
+  - URL: `/api/v1/{resource}`
+
+- **[IPA-106](ipa/general/0106.md): CREATE**
+  - Create a new resource
+  - HTTP POST to collection URL
+  - Returns created resource
+
+- **[IPA-107](ipa/general/0107.md): UPDATE**
+  - Modify an existing resource
+  - HTTP PATCH or PUT
+  - Returns updated resource
+
+- **[IPA-108](ipa/general/0108.md): DELETE**
+  - Remove a resource
+  - HTTP DELETE
+  - Returns 204 No Content or deleted resource
+
+- **[IPA-109](ipa/general/0109.md): Custom Methods**
+  - Operations that don't fit standard methods
+  - HTTP POST with `:verb` suffix
+  - Example: `POST /api/v1/clusters/{clusterId}:restart`
+
+#### Common Patterns
+- **[IPA-110](ipa/general/0110.md): Pagination**
+  - Use `pageToken` and `pageSize` parameters
+  - Return `nextPageToken` in response
+  - Consistent pagination across LIST operations
+
+- **[IPA-114](ipa/general/0114.md): Errors**
+  - Structured error responses
+  - Include `code`, `message`, and `detail` fields
+  - Appropriate HTTP status codes
+
+- **[IPA-116](ipa/general/0116.md): Backwards Compatibility**
+  - Avoid breaking changes
+  - Deprecation strategy for necessary changes
+  - Version migration paths
+
+- **[IPA-118](ipa/general/0118.md): Extensible by Default**
+  - Design for future extensibility
+  - Use extensible data structures
+  - Avoid closed enumerations
+
+- **[IPA-120](ipa/general/0120.md): Versioning**
+  - Version in URL path: `/api/v1/`
+  - Major version for breaking changes
+  - Clear version migration documentation
+
+- **[IPA-121](ipa/general/0121.md): Datetime**
+  - Use ISO 8601 format
+  - UTC timezone
+  - Example: `2024-01-15T10:30:00Z`
+
+- **[IPA-122](ipa/general/0122.md): Standard Codes**
+  - Consistent error and status codes
+  - Machine-readable codes
+  - Human-readable messages
+
+#### Meta-IPAs
+- **[IPA-5](ipa/general/0005.md): Documenting Exceptions**
+  - How to document IPA exceptions
+  - `x-xgen-IPA-exception` format
+  - Required fields: reason, impact, mitigation, timeline
+
+### Key Links
+
+| Resource | Link |
+|----------|------|
+| **IPA Documentation** | https://mongodb.github.io/ipa/ |
+| **IPA Validation (Spectral)** | [docs/external/ipa-validation-README.md](docs/external/ipa-validation-README.md) |
+| **Spectral Ruleset** | https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme |
+| **API Designs Folder** | [api-designs/](api-designs/) |
+| **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) |
+
+### Common IPA Patterns
+
+#### Resource URL Pattern
+```
+/api/v{majorVersion}/{resourcePlural}/{resourceId}
+```
+Examples:
+- `/api/v1/clusters/cluster-123`
+- `/api/v1/backups/backup-456`
+- `/api/v2/databases/db-789`
+
+#### Standard Method URLs
+```
+GET    /api/v1/clusters/{clusterId}      # Get single resource
+GET    /api/v1/clusters                  # List resources
+POST   /api/v1/clusters                  # Create resource
+PATCH  /api/v1/clusters/{clusterId}      # Update resource
+DELETE /api/v1/clusters/{clusterId}      # Delete resource
+```
+
+#### Custom Method URL
+```
+POST /api/v1/clusters/{clusterId}:restart
+POST /api/v1/backups/{backupId}:restore
+POST /api/v1/databases/{databaseId}:export
+```
+
+#### Pagination Parameters
+```
+GET /api/v1/clusters?pageToken={token}&pageSize=20
+```
+
+Response:
+```json
+{
+  "clusters": [...],
+  "nextPageToken": "eyJvZmZzZXQiOjIwfQ=="
+}
+```
+
+#### Error Response Structure
+```json
+{
+  "error": {
+    "code": "RESOURCE_NOT_FOUND",
+    "message": "Cluster 'cluster-123' not found",
+    "detail": {
+      "resourceType": "cluster",
+      "resourceId": "cluster-123"
+    }
+  }
+}
+```
+
+## Best Practices for AI Agents
+
+### 1. Always Read the Full IPA Before Citing
+
+Don't rely on IPA titles alone. Read the complete IPA document to understand:
+- The specific requirements (MUST, SHOULD, MAY)
+- The rationale behind the guideline
+- Examples and counter-examples
+- Related IPAs
+
+### 2. Consider Context and Trade-offs
+
+Not every situation is straightforward. When providing guidance:
+- **Acknowledge constraints**: Legacy systems, performance requirements, domain-specific needs
+- **Explain trade-offs**: What are the pros and cons of different approaches?
+- **Provide options**: When multiple valid approaches exist, present them with rationale
+- **Be pragmatic**: Perfect IPA compliance isn't always possible or necessary
+
+### 3. Provide Actionable, Specific Recommendations
+
+Vague advice isn't helpful. Instead:
+
+❌ **Bad**: "This doesn't follow REST principles"
+✅ **Good**: "According to IPA-101, use `/api/v1/clusters/{clusterId}` instead of `/getCluster?id={clusterId}`"
+
+❌ **Bad**: "You need better error handling"
+✅ **Good**: "Per IPA-114, add a structured error response with `code`, `message`, and `detail` fields. Here's an example: [code snippet]"
+
+### 4. Include Code Examples
+
+Show, don't just tell. Provide:
+- **Before/after comparisons**: Show the current state and the improved version
+- **Complete examples**: Include enough context to be useful
+- **Proper formatting**: Use YAML/JSON syntax highlighting
+- **Inline comments**: Explain key parts of the example
+
+### 5. Link Related IPAs
+
+IPAs often reference each other. When citing one IPA:
+- **Mention related IPAs**: "IPA-105 (LIST) works with IPA-110 (Pagination)"
+- **Explain relationships**: How do these IPAs work together?
+- **Provide integrated guidance**: Show how to satisfy multiple IPAs simultaneously
+
+### 6. Respect IPA States
+
+Pay attention to IPA maturity:
+- **Adopt**: Recommend strongly, treat as standard
+- **Experimental**: Mention as optional, note experimental status
+- **Deprecated**: Warn against use, suggest alternatives
+- **Retired**: Don't recommend, explain historical context if relevant
+
+### 7. Suggest Validation
+
+After providing recommendations:
+- **Suggest Spectral validation**: "Run `npx spectral lint openapi.yaml` to check for issues"
+- **Explain validation results**: Help interpret linting errors
+- **Provide fixes**: Show how to address validation failures
+- **Document exceptions**: Help write proper exception documentation
+
+### 8. Help Developers Understand "Why"
+
+Don't just enforce rules. Explain:
+- **The purpose**: Why does this IPA exist?
+- **The benefits**: What problems does it solve?
+- **The consequences**: What happens if you don't follow it?
+- **The alternatives**: Are there other valid approaches?
+
+**Example**:
+```
+IPA-110 (Pagination) requires using pageToken instead of offset/limit because:
+- Tokens are stable even when data changes
+- Prevents skipped or duplicate items during pagination
+- More efficient for large datasets
+- Consistent with industry best practices
+
+If you must use offset/limit for legacy reasons, document the exception
+and explain the trade-offs to API consumers.
+```
+
+### 9. Be Aware of IPA Evolution
+
+IPAs evolve over time:
+- **Check IPA state**: Is this still "Adopt" or has it been deprecated?
+- **Note recent changes**: Has the IPA been updated recently?
+- **Suggest updates**: "This design follows IPA-XXX v1, but v2 has new recommendations"
+- **Stay current**: Periodically review IPA documentation for updates
+
+### 10. Encourage Consistency
+
+Consistency is key to good API design:
+- **Check existing patterns**: "Your other endpoints use pageToken; this one should too"
+- **Suggest standardization**: "Let's align this with your clusters API design"
+- **Reference internal examples**: "This follows the same pattern as your backups API"
+- **Build on precedent**: "Since you're already using IPA-101 elsewhere, apply it here too"
+
+### 11. Document Decisions
+
+Help developers capture their reasoning:
+- **Suggest creating design-notes.md**: Document why decisions were made
+- **Update ipa-compliance.md**: Track which IPAs are followed
+- **Record exceptions**: Use proper exception documentation format
+- **Maintain history**: Keep track of design evolution
+
+### 12. Balance Perfectionism with Pragmatism
+
+Perfect IPA compliance isn't always achievable or necessary:
+- **Prioritize**: Focus on MUST requirements first
+- **Be flexible**: SHOULD requirements may have valid exceptions
+- **Consider ROI**: Is the effort to fix this issue worth the benefit?
+- **Plan incrementally**: "Fix critical issues now, improve others in v2"
+
+---
+
+## Conclusion
+
+This document provides comprehensive guidance for AI agents working with MongoDB's IPA guidelines. By following these practices, agents can:
+
+- **Provide valuable, actionable feedback** on API designs
+- **Help developers understand and apply** IPA principles
+- **Balance idealism with pragmatism** in real-world constraints
+- **Improve API consistency and quality** across MongoDB's platform
+
+For questions or suggestions about these guidelines, please open an issue or contribute to this document following the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: 2024-01-15
+**Maintained By**: MongoDB API Experience Team
+
+

--- a/api-designs/.gitkeep
+++ b/api-designs/.gitkeep
@@ -1,0 +1,3 @@
+# This file ensures the api-designs directory is tracked by git
+# API design documents will be stored in subdirectories here
+

--- a/api-designs/README.md
+++ b/api-designs/README.md
@@ -1,8 +1,8 @@
 # API Designs
 
-This folder contains API design documents and OpenAPI specifications that are
-being developed or reviewed against MongoDB's IPA (Improvement Proposal for
-APIs) guidelines.
+This folder contains API design documents in markdown format that are being
+developed or reviewed against MongoDB's IPA (Improvement Proposal for APIs)
+guidelines.
 
 ## Purpose
 
@@ -20,20 +20,19 @@ Each API design should be organized in its own subdirectory:
 ```text
 api-designs/
 ├── <project-name>/
-│   ├── openapi.yaml              # OpenAPI 3.x specification
+│   ├── api-design.md             # API design document in markdown
 │   ├── design-notes.md           # Design rationale and decisions
-│   ├── ipa-compliance.md         # IPA compliance checklist
-│   └── .spectral.yaml            # (Optional) Spectral configuration
+│   └── ipa-compliance.md         # IPA compliance checklist
 └── README.md                     # This file
 ```
 
 ### File Descriptions
 
-#### `openapi.yaml` (Required)
+#### `api-design.md` (Required)
 
-Your OpenAPI 3.x specification file. This should follow the
-[OpenAPI Specification](https://spec.openapis.org/oas/latest.html) format and
-adhere to IPA guidelines.
+Your API design document in markdown format. This should describe your API
+endpoints, resources, request/response formats, and how they follow IPA
+guidelines. Use clear examples and structure.
 
 #### `design-notes.md` (Recommended)
 
@@ -68,19 +67,6 @@ Document any IPA exceptions using the format from IPA-5:
 - **IPA-XXX**: [Reason for exception and mitigation strategy]
 ```
 
-#### `.spectral.yaml` (Optional)
-
-If you want to run automated IPA validation, create a Spectral configuration:
-
-```yaml
-extends:
-  - "@mongodb/ipa-validation-ruleset"
-```
-
-See
-[docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md)
-for details.
-
 ## Working with AI Agents
 
 This folder is designed to work seamlessly with AI agents. When working with an
@@ -88,8 +74,8 @@ agent:
 
 1. **Start a new design**: Ask the agent to create a new project folder with the
    recommended structure
-2. **Review existing designs**: Point the agent to your OpenAPI spec for IPA
-   compliance review
+2. **Review existing designs**: Point the agent to your API design document for
+   IPA compliance review
 3. **Iterate on designs**: Work with the agent to refine your API based on IPA
    feedback
 4. **Document exceptions**: Have the agent help document any necessary IPA
@@ -100,7 +86,7 @@ agent:
 ```text
 "Create a new API design for managing database backups in api-designs/backups/ following IPA guidelines"
 
-"Review my API design in api-designs/clusters/openapi.yaml against IPA-101 through IPA-108"
+"Review my API design in api-designs/clusters/api-design.md against IPA-101 through IPA-108"
 
 "Help me document an IPA-105 exception for my legacy pagination implementation"
 ```
@@ -108,26 +94,18 @@ agent:
 See [agents.md](../agents.md) for comprehensive guidance on working with AI
 agents and IPA guidelines.
 
-## Validation
+## Review Process
 
-### Automated Validation with Spectral
+Work with AI agents to review your API design against IPA guidelines. The agent
+will help you:
 
-Install the IPA validation ruleset:
+- Identify which IPAs apply to your design
+- Suggest improvements based on IPA best practices
+- Document any necessary exceptions
+- Ensure consistency with MongoDB API standards
 
-```bash
-npm install @mongodb-js/ipa-validation-ruleset
-```
-
-Run validation:
-
-```bash
-npx spectral lint api-designs/<project-name>/openapi.yaml --ruleset=.spectral.yaml
-```
-
-### Manual Review
-
-Use the [IPA documentation](https://mongodb.github.io/ipa/) to manually review
-your design against relevant guidelines.
+See [agents.md](../agents.md) for detailed guidance on working with AI agents
+for API design reviews.
 
 ## Best Practices
 
@@ -135,17 +113,16 @@ your design against relevant guidelines.
 2. **Iterate early**: Get feedback on your design early and often
 3. **Document decisions**: Capture your reasoning in design-notes.md
 4. **Track compliance**: Use the IPA compliance checklist
-5. **Validate automatically**: Run Spectral validation regularly
+5. **Work with AI agents**: Leverage AI agents to review designs against IPA
+   guidelines
 6. **Justify exceptions**: Document any IPA exceptions with clear rationale
 
 ## Resources
 
 - **IPA Documentation**: <https://mongodb.github.io/ipa/>
-- **IPA Validation**:
-  [docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md)
 - **Agent Guidelines**: [agents.md](../agents.md)
-- **OpenAPI Specification**: <https://spec.openapis.org/oas/latest.html>
-- **Spectral Documentation**: <https://docs.stoplight.io/docs/spectral/>
+- **IPA Validation Reference**:
+  [docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md)
 
 ## Questions?
 

--- a/api-designs/README.md
+++ b/api-designs/README.md
@@ -1,0 +1,131 @@
+# API Designs
+
+This folder contains API design documents and OpenAPI specifications that are being developed or reviewed against MongoDB's IPA (Improvement Proposal for APIs) guidelines.
+
+## Purpose
+
+This directory serves as a workspace for:
+- **Developing new API designs** following IPA guidelines
+- **Reviewing existing APIs** for IPA compliance
+- **Collaborating with AI agents** on API design improvements
+- **Documenting design decisions** and IPA exceptions
+
+## Folder Structure
+
+Each API design should be organized in its own subdirectory:
+
+```
+api-designs/
+├── <project-name>/
+│   ├── openapi.yaml              # OpenAPI 3.x specification
+│   ├── design-notes.md           # Design rationale and decisions
+│   ├── ipa-compliance.md         # IPA compliance checklist
+│   └── .spectral.yaml            # (Optional) Spectral configuration
+└── README.md                     # This file
+```
+
+### File Descriptions
+
+#### `openapi.yaml` (Required)
+Your OpenAPI 3.x specification file. This should follow the [OpenAPI Specification](https://spec.openapis.org/oas/latest.html) format and adhere to IPA guidelines.
+
+#### `design-notes.md` (Recommended)
+Document your design decisions, trade-offs, and rationale. Include:
+- **Problem statement**: What problem does this API solve?
+- **Design approach**: Why did you choose this design?
+- **Alternatives considered**: What other approaches did you evaluate?
+- **Trade-offs**: What compromises were made and why?
+
+#### `ipa-compliance.md` (Recommended)
+Track compliance with relevant IPAs. Use this template:
+
+```markdown
+# IPA Compliance Checklist
+
+## Core IPAs
+- [ ] IPA-101: Resource-Oriented Design
+- [ ] IPA-102: Resource Identifiers
+- [ ] IPA-103: Methods
+- [ ] IPA-110: Pagination
+- [ ] IPA-114: Errors
+- [ ] IPA-116: Backwards Compatibility
+- [ ] IPA-120: Versioning
+
+## Exceptions
+Document any IPA exceptions using the format from IPA-5:
+- **IPA-XXX**: [Reason for exception and mitigation strategy]
+```
+
+#### `.spectral.yaml` (Optional)
+If you want to run automated IPA validation, create a Spectral configuration:
+
+```yaml
+extends:
+  - "@mongodb/ipa-validation-ruleset"
+```
+
+See [docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md) for details.
+
+## Working with AI Agents
+
+This folder is designed to work seamlessly with AI agents. When working with an agent:
+
+1. **Start a new design**: Ask the agent to create a new project folder with the recommended structure
+2. **Review existing designs**: Point the agent to your OpenAPI spec for IPA compliance review
+3. **Iterate on designs**: Work with the agent to refine your API based on IPA feedback
+4. **Document exceptions**: Have the agent help document any necessary IPA exceptions
+
+### Example Prompts
+
+```
+"Create a new API design for managing database backups in api-designs/backups/ following IPA guidelines"
+
+"Review my API design in api-designs/clusters/openapi.yaml against IPA-101 through IPA-108"
+
+"Help me document an IPA-105 exception for my legacy pagination implementation"
+```
+
+See [agents.md](../agents.md) for comprehensive guidance on working with AI agents and IPA guidelines.
+
+## Validation
+
+### Automated Validation with Spectral
+
+Install the IPA validation ruleset:
+```bash
+npm install @mongodb-js/ipa-validation-ruleset
+```
+
+Run validation:
+```bash
+npx spectral lint api-designs/<project-name>/openapi.yaml --ruleset=.spectral.yaml
+```
+
+### Manual Review
+
+Use the [IPA documentation](https://mongodb.github.io/ipa/) to manually review your design against relevant guidelines.
+
+## Best Practices
+
+1. **Start with IPAs**: Review relevant IPAs before designing your API
+2. **Iterate early**: Get feedback on your design early and often
+3. **Document decisions**: Capture your reasoning in design-notes.md
+4. **Track compliance**: Use the IPA compliance checklist
+5. **Validate automatically**: Run Spectral validation regularly
+6. **Justify exceptions**: Document any IPA exceptions with clear rationale
+
+## Resources
+
+- **IPA Documentation**: https://mongodb.github.io/ipa/
+- **IPA Validation**: [docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md)
+- **Agent Guidelines**: [agents.md](../agents.md)
+- **OpenAPI Specification**: https://spec.openapis.org/oas/latest.html
+- **Spectral Documentation**: https://docs.stoplight.io/docs/spectral/
+
+## Questions?
+
+For questions about:
+- **IPA guidelines**: See the [IPA documentation](https://mongodb.github.io/ipa/)
+- **Using this folder**: See [agents.md](../agents.md)
+- **Contributing to IPAs**: See [CONTRIBUTING.md](../CONTRIBUTING.md)
+

--- a/api-designs/README.md
+++ b/api-designs/README.md
@@ -17,7 +17,7 @@ This directory serves as a workspace for:
 
 Each API design should be organized in its own subdirectory:
 
-```
+```text
 api-designs/
 ├── <project-name>/
 │   ├── openapi.yaml              # OpenAPI 3.x specification
@@ -97,7 +97,7 @@ agent:
 
 ### Example Prompts
 
-```
+```text
 "Create a new API design for managing database backups in api-designs/backups/ following IPA guidelines"
 
 "Review my API design in api-designs/clusters/openapi.yaml against IPA-101 through IPA-108"
@@ -140,12 +140,12 @@ your design against relevant guidelines.
 
 ## Resources
 
-- **IPA Documentation**: https://mongodb.github.io/ipa/
+- **IPA Documentation**: <https://mongodb.github.io/ipa/>
 - **IPA Validation**:
   [docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md)
 - **Agent Guidelines**: [agents.md](../agents.md)
-- **OpenAPI Specification**: https://spec.openapis.org/oas/latest.html
-- **Spectral Documentation**: https://docs.stoplight.io/docs/spectral/
+- **OpenAPI Specification**: <https://spec.openapis.org/oas/latest.html>
+- **Spectral Documentation**: <https://docs.stoplight.io/docs/spectral/>
 
 ## Questions?
 

--- a/api-designs/README.md
+++ b/api-designs/README.md
@@ -1,10 +1,13 @@
 # API Designs
 
-This folder contains API design documents and OpenAPI specifications that are being developed or reviewed against MongoDB's IPA (Improvement Proposal for APIs) guidelines.
+This folder contains API design documents and OpenAPI specifications that are
+being developed or reviewed against MongoDB's IPA (Improvement Proposal for
+APIs) guidelines.
 
 ## Purpose
 
 This directory serves as a workspace for:
+
 - **Developing new API designs** following IPA guidelines
 - **Reviewing existing APIs** for IPA compliance
 - **Collaborating with AI agents** on API design improvements
@@ -27,22 +30,29 @@ api-designs/
 ### File Descriptions
 
 #### `openapi.yaml` (Required)
-Your OpenAPI 3.x specification file. This should follow the [OpenAPI Specification](https://spec.openapis.org/oas/latest.html) format and adhere to IPA guidelines.
+
+Your OpenAPI 3.x specification file. This should follow the
+[OpenAPI Specification](https://spec.openapis.org/oas/latest.html) format and
+adhere to IPA guidelines.
 
 #### `design-notes.md` (Recommended)
+
 Document your design decisions, trade-offs, and rationale. Include:
+
 - **Problem statement**: What problem does this API solve?
 - **Design approach**: Why did you choose this design?
 - **Alternatives considered**: What other approaches did you evaluate?
 - **Trade-offs**: What compromises were made and why?
 
 #### `ipa-compliance.md` (Recommended)
+
 Track compliance with relevant IPAs. Use this template:
 
 ```markdown
 # IPA Compliance Checklist
 
 ## Core IPAs
+
 - [ ] IPA-101: Resource-Oriented Design
 - [ ] IPA-102: Resource Identifiers
 - [ ] IPA-103: Methods
@@ -52,11 +62,14 @@ Track compliance with relevant IPAs. Use this template:
 - [ ] IPA-120: Versioning
 
 ## Exceptions
+
 Document any IPA exceptions using the format from IPA-5:
+
 - **IPA-XXX**: [Reason for exception and mitigation strategy]
 ```
 
 #### `.spectral.yaml` (Optional)
+
 If you want to run automated IPA validation, create a Spectral configuration:
 
 ```yaml
@@ -64,16 +77,23 @@ extends:
   - "@mongodb/ipa-validation-ruleset"
 ```
 
-See [docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md) for details.
+See
+[docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md)
+for details.
 
 ## Working with AI Agents
 
-This folder is designed to work seamlessly with AI agents. When working with an agent:
+This folder is designed to work seamlessly with AI agents. When working with an
+agent:
 
-1. **Start a new design**: Ask the agent to create a new project folder with the recommended structure
-2. **Review existing designs**: Point the agent to your OpenAPI spec for IPA compliance review
-3. **Iterate on designs**: Work with the agent to refine your API based on IPA feedback
-4. **Document exceptions**: Have the agent help document any necessary IPA exceptions
+1. **Start a new design**: Ask the agent to create a new project folder with the
+   recommended structure
+2. **Review existing designs**: Point the agent to your OpenAPI spec for IPA
+   compliance review
+3. **Iterate on designs**: Work with the agent to refine your API based on IPA
+   feedback
+4. **Document exceptions**: Have the agent help document any necessary IPA
+   exceptions
 
 ### Example Prompts
 
@@ -85,25 +105,29 @@ This folder is designed to work seamlessly with AI agents. When working with an 
 "Help me document an IPA-105 exception for my legacy pagination implementation"
 ```
 
-See [agents.md](../agents.md) for comprehensive guidance on working with AI agents and IPA guidelines.
+See [agents.md](../agents.md) for comprehensive guidance on working with AI
+agents and IPA guidelines.
 
 ## Validation
 
 ### Automated Validation with Spectral
 
 Install the IPA validation ruleset:
+
 ```bash
 npm install @mongodb-js/ipa-validation-ruleset
 ```
 
 Run validation:
+
 ```bash
 npx spectral lint api-designs/<project-name>/openapi.yaml --ruleset=.spectral.yaml
 ```
 
 ### Manual Review
 
-Use the [IPA documentation](https://mongodb.github.io/ipa/) to manually review your design against relevant guidelines.
+Use the [IPA documentation](https://mongodb.github.io/ipa/) to manually review
+your design against relevant guidelines.
 
 ## Best Practices
 
@@ -117,7 +141,8 @@ Use the [IPA documentation](https://mongodb.github.io/ipa/) to manually review y
 ## Resources
 
 - **IPA Documentation**: https://mongodb.github.io/ipa/
-- **IPA Validation**: [docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md)
+- **IPA Validation**:
+  [docs/external/ipa-validation-README.md](../docs/external/ipa-validation-README.md)
 - **Agent Guidelines**: [agents.md](../agents.md)
 - **OpenAPI Specification**: https://spec.openapis.org/oas/latest.html
 - **Spectral Documentation**: https://docs.stoplight.io/docs/spectral/
@@ -125,7 +150,8 @@ Use the [IPA documentation](https://mongodb.github.io/ipa/) to manually review y
 ## Questions?
 
 For questions about:
-- **IPA guidelines**: See the [IPA documentation](https://mongodb.github.io/ipa/)
+
+- **IPA guidelines**: See the
+  [IPA documentation](https://mongodb.github.io/ipa/)
 - **Using this folder**: See [agents.md](../agents.md)
 - **Contributing to IPAs**: See [CONTRIBUTING.md](../CONTRIBUTING.md)
-

--- a/docs/external/ipa-validation-README.md
+++ b/docs/external/ipa-validation-README.md
@@ -1,17 +1,24 @@
 # IPA Validation
 
-> **Note**: This file is automatically synced from the [mongodb/openapi repository](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/README.md).
-> To update this file, run `./scripts/update-external-docs.sh` from the repository root.
+> **Note**: This file is automatically synced from the
+> [mongodb/openapi repository](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/README.md).
+> To update this file, run `./scripts/update-external-docs.sh` from the
+> repository root.
 
-The IPA validation uses [Spectral](https://docs.stoplight.io/docs/spectral/9ffa04e052cc1-spectral-cli) to validate the [MongoDB Atlas Admin API OpenAPI Specification](https://github.com/mongodb/openapi/tree/main/openapi). The rules cover MongoDB's [Improvement Proposal for APIs](https://mongodb.github.io/ipa/) (IPA), which are best-practices for API design.
-
+The IPA validation uses
+[Spectral](https://docs.stoplight.io/docs/spectral/9ffa04e052cc1-spectral-cli)
+to validate the
+[MongoDB Atlas Admin API OpenAPI Specification](https://github.com/mongodb/openapi/tree/main/openapi).
+The rules cover MongoDB's
+[Improvement Proposal for APIs](https://mongodb.github.io/ipa/) (IPA), which are
+best-practices for API design.
 
 ## Quick Links
 
 | Site                        | Link                                                                                                     |
 | --------------------------- | -------------------------------------------------------------------------------------------------------- |
 | MongoDB API Standards (IPA) | [https://mongodb.github.io/ipa/](https://mongodb.github.io/ipa/)                                         |
-| Installation & Usage           | [IPA README](https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa#readme) |
+| Installation & Usage        | [IPA README](https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa#readme)                     |
 | Implemented Rules           | [Ruleset Documentation](https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme) |
 | Spectral Docs               | [Spectral](https://docs.stoplight.io/docs/spectral/674b27b261c3c-overview)                               |
 | Contributing                | [CONTRIBUTING.md](https://github.com/mongodb/openapi/blob/main/tools/spectral/CONTRIBUTING.md)           |
@@ -27,28 +34,42 @@ The IPA validation uses [Spectral](https://docs.stoplight.io/docs/spectral/9ffa0
 
 ### Run Validation
 
-To run the IPA validation locally, install necessary dependencies with `npm install` if you haven't already. Then (from `/openapi/tools/spectral/ipa/metrics/scripts/`), simply run:
+To run the IPA validation locally, install necessary dependencies with
+`npm install` if you haven't already. Then (from
+`/openapi/tools/spectral/ipa/metrics/scripts/`), simply run:
 
 ```
 npm run ipa-validation
 ```
 
-This command will run Spectral CLI for the ruleset [ipa-spectral.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/ipa-spectral.yaml) on the raw [v2.yaml](https://github.com/mongodb/openapi/blob/main/openapi/.raw/v2.yaml) OpenAPI spec and generate `ipa-collector-results-combined.log`.
+This command will run Spectral CLI for the ruleset
+[ipa-spectral.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/ipa-spectral.yaml)
+on the raw
+[v2.yaml](https://github.com/mongodb/openapi/blob/main/openapi/.raw/v2.yaml)
+OpenAPI spec and generate `ipa-collector-results-combined.log`.
 
 ## Integrating IPA Validations
 
-To incorporate the IPA Spectral ruleset for OpenAPI specification validation in your repositories, you can follow these implementation approaches:
+To incorporate the IPA Spectral ruleset for OpenAPI specification validation in
+your repositories, you can follow these implementation approaches:
 
 ### Installation Options
 
 #### Package-based Installation
+
 Run:
+
 ```
 npm install @mongodb-js/ipa-validation-ruleset
 ```
 
 #### Limitations
-The IPA Validation Framework uses third party dependencies for certain rules. With this approach, [server based installation](https://docs.stoplight.io/docs/spectral/7895ff1196448-sharing-and-distributing-rulesets#http-server) is not supported. Instead, use the recommended package-based installation or clone the repo.
+
+The IPA Validation Framework uses third party dependencies for certain rules.
+With this approach,
+[server based installation](https://docs.stoplight.io/docs/spectral/7895ff1196448-sharing-and-distributing-rulesets#http-server)
+is not supported. Instead, use the recommended package-based installation or
+clone the repo.
 
 ### Integration Methods
 
@@ -61,11 +82,13 @@ extends:
 - "@mongodb/ipa-validation-ruleset"
 ```
 
-For more information about how to extend rulesets, see the [web page](https://meta.stoplight.io/docs/spectral/83527ef2dd8c0-extending-rulesets).
+For more information about how to extend rulesets, see the
+[web page](https://meta.stoplight.io/docs/spectral/83527ef2dd8c0-extending-rulesets).
 
 #### Customization Options
 
-You can override specific rules from our ruleset by adding them to your local `.spectral.yaml`:
+You can override specific rules from our ruleset by adding them to your local
+`.spectral.yaml`:
 
 ```
 extends:
@@ -83,7 +106,8 @@ overrides:
 
 #### GitHub Actions Example
 
-If you use GitHub Actions, you can define a workflow step to include IPA validation, such as
+If you use GitHub Actions, you can define a workflow step to include IPA
+validation, such as
 
 ```
 - name: IPA validation action
@@ -100,9 +124,11 @@ or
         spectral_ruleset: <spectral-ruleset-file>
 ```
 
-`<spectral-ruleset-file>` is the ruleset file which extends the IPA Spectral ruleset.
+`<spectral-ruleset-file>` is the ruleset file which extends the IPA Spectral
+ruleset.
 
-For more information about Spectral GitHub action, see the [GitHub repo](https://github.com/stoplightio/spectral-action).
+For more information about Spectral GitHub action, see the
+[GitHub repo](https://github.com/stoplightio/spectral-action).
 
 #### Shell Script Example
 
@@ -117,7 +143,8 @@ exit 1
 fi
 ```
 
-For more information on Spectral CLI, see the [web page](https://meta.stoplight.io/docs/spectral/9ffa04e052cc1-spectral-cli).
+For more information on Spectral CLI, see the
+[web page](https://meta.stoplight.io/docs/spectral/9ffa04e052cc1-spectral-cli).
 
 #### Bazel Target Example
 
@@ -136,4 +163,3 @@ deps = [
 ],
 )
 ```
-

--- a/docs/external/ipa-validation-README.md
+++ b/docs/external/ipa-validation-README.md
@@ -38,7 +38,7 @@ To run the IPA validation locally, install necessary dependencies with
 `npm install` if you haven't already. Then (from
 `/openapi/tools/spectral/ipa/metrics/scripts/`), simply run:
 
-```
+```bash
 npm run ipa-validation
 ```
 
@@ -59,7 +59,7 @@ your repositories, you can follow these implementation approaches:
 
 Run:
 
-```
+```bash
 npm install @mongodb-js/ipa-validation-ruleset
 ```
 
@@ -77,9 +77,9 @@ clone the repo.
 
 Create a `.spectral.yaml` file that extends our ruleset:
 
-```
+```yaml
 extends:
-- "@mongodb/ipa-validation-ruleset"
+  - "@mongodb/ipa-validation-ruleset"
 ```
 
 For more information about how to extend rulesets, see the
@@ -90,7 +90,7 @@ For more information about how to extend rulesets, see the
 You can override specific rules from our ruleset by adding them to your local
 `.spectral.yaml`:
 
-```
+```yaml
 extends:
 - "@mongodb/ipa-validation-ruleset"
 
@@ -109,19 +109,19 @@ overrides:
 If you use GitHub Actions, you can define a workflow step to include IPA
 validation, such as
 
-```
+```yaml
 - name: IPA validation action
 run: npx spectral lint <openapi-spec-file> --ruleset=<spectral-ruleset-file>
 ```
 
 or
 
-```
-    - name: IPA validation - Spectral GitHub action
-      uses: stoplightio/spectral-action@2ad0b9302e32a77c1caccf474a9b2191a8060d83
-      with:
-        file_glob: <openapi-spec-file>
-        spectral_ruleset: <spectral-ruleset-file>
+```yaml
+- name: IPA validation - Spectral GitHub action
+  uses: stoplightio/spectral-action@2ad0b9302e32a77c1caccf474a9b2191a8060d83
+  with:
+    file_glob: <openapi-spec-file>
+    spectral_ruleset: <spectral-ruleset-file>
 ```
 
 `<spectral-ruleset-file>` is the ruleset file which extends the IPA Spectral
@@ -150,7 +150,7 @@ For more information on Spectral CLI, see the
 
 You can create a Bazel target using the shell script similar to:
 
-```
+```python
 sh_binary(
 name = "ipa_validation",
 srcs = ["ipa_validation.sh"],

--- a/docs/external/ipa-validation-README.md
+++ b/docs/external/ipa-validation-README.md
@@ -1,0 +1,139 @@
+# IPA Validation
+
+> **Note**: This file is automatically synced from the [mongodb/openapi repository](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/README.md).
+> To update this file, run `./scripts/update-external-docs.sh` from the repository root.
+
+The IPA validation uses [Spectral](https://docs.stoplight.io/docs/spectral/9ffa04e052cc1-spectral-cli) to validate the [MongoDB Atlas Admin API OpenAPI Specification](https://github.com/mongodb/openapi/tree/main/openapi). The rules cover MongoDB's [Improvement Proposal for APIs](https://mongodb.github.io/ipa/) (IPA), which are best-practices for API design.
+
+
+## Quick Links
+
+| Site                        | Link                                                                                                     |
+| --------------------------- | -------------------------------------------------------------------------------------------------------- |
+| MongoDB API Standards (IPA) | [https://mongodb.github.io/ipa/](https://mongodb.github.io/ipa/)                                         |
+| Installation & Usage           | [IPA README](https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa#readme) |
+| Implemented Rules           | [Ruleset Documentation](https://github.com/mongodb/openapi/tree/main/tools/spectral/ipa/rulesets#readme) |
+| Spectral Docs               | [Spectral](https://docs.stoplight.io/docs/spectral/674b27b261c3c-overview)                               |
+| Contributing                | [CONTRIBUTING.md](https://github.com/mongodb/openapi/blob/main/tools/spectral/CONTRIBUTING.md)           |
+| Changelog                   | [CHANGELOG.md](https://github.com/mongodb/openapi/blob/main/tools/spectral/CHANGELOG.md)                 |
+| Issues                      | [https://github.com/mongodb/openapi/issues](https://github.com/mongodb/openapi/issues)                   |
+
+## Running Locally
+
+### Prerequisites
+
+- Node.js >= v20
+- npm
+
+### Run Validation
+
+To run the IPA validation locally, install necessary dependencies with `npm install` if you haven't already. Then (from `/openapi/tools/spectral/ipa/metrics/scripts/`), simply run:
+
+```
+npm run ipa-validation
+```
+
+This command will run Spectral CLI for the ruleset [ipa-spectral.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/ipa-spectral.yaml) on the raw [v2.yaml](https://github.com/mongodb/openapi/blob/main/openapi/.raw/v2.yaml) OpenAPI spec and generate `ipa-collector-results-combined.log`.
+
+## Integrating IPA Validations
+
+To incorporate the IPA Spectral ruleset for OpenAPI specification validation in your repositories, you can follow these implementation approaches:
+
+### Installation Options
+
+#### Package-based Installation
+Run:
+```
+npm install @mongodb-js/ipa-validation-ruleset
+```
+
+#### Limitations
+The IPA Validation Framework uses third party dependencies for certain rules. With this approach, [server based installation](https://docs.stoplight.io/docs/spectral/7895ff1196448-sharing-and-distributing-rulesets#http-server) is not supported. Instead, use the recommended package-based installation or clone the repo.
+
+### Integration Methods
+
+#### Local Configuration
+
+Create a `.spectral.yaml` file that extends our ruleset:
+
+```
+extends:
+- "@mongodb/ipa-validation-ruleset"
+```
+
+For more information about how to extend rulesets, see the [web page](https://meta.stoplight.io/docs/spectral/83527ef2dd8c0-extending-rulesets).
+
+#### Customization Options
+
+You can override specific rules from our ruleset by adding them to your local `.spectral.yaml`:
+
+```
+extends:
+- "@mongodb/ipa-validation-ruleset"
+
+overrides:
+    - files:
+        '**#/components/schemas/ExampleSchema'
+        '**#/paths/example-path'
+       rules:
+         x-xgen-IPA-xxx-rule: 'off'
+```
+
+### CI/CD Integration
+
+#### GitHub Actions Example
+
+If you use GitHub Actions, you can define a workflow step to include IPA validation, such as
+
+```
+- name: IPA validation action
+run: npx spectral lint <openapi-spec-file> --ruleset=<spectral-ruleset-file>
+```
+
+or
+
+```
+    - name: IPA validation - Spectral GitHub action
+      uses: stoplightio/spectral-action@2ad0b9302e32a77c1caccf474a9b2191a8060d83
+      with:
+        file_glob: <openapi-spec-file>
+        spectral_ruleset: <spectral-ruleset-file>
+```
+
+`<spectral-ruleset-file>` is the ruleset file which extends the IPA Spectral ruleset.
+
+For more information about Spectral GitHub action, see the [GitHub repo](https://github.com/stoplightio/spectral-action).
+
+#### Shell Script Example
+
+You can create a validation script similar to this:
+
+```bash
+#!/bin/bash
+spectral lint <openapi-spec-file> --ruleset=<spectral-ruleset-file>
+if [ $? -ne 0 ]; then
+echo "API validation failed"
+exit 1
+fi
+```
+
+For more information on Spectral CLI, see the [web page](https://meta.stoplight.io/docs/spectral/9ffa04e052cc1-spectral-cli).
+
+#### Bazel Target Example
+
+You can create a Bazel target using the shell script similar to:
+
+```
+sh_binary(
+name = "ipa_validation",
+srcs = ["ipa_validation.sh"],
+data = [
+":spectral",
+":spectral_config",
+],
+deps = [
+"@bazel_tools//tools/bash/runfiles",
+],
+)
+```
+

--- a/scripts/update-external-docs.sh
+++ b/scripts/update-external-docs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Script to update external documentation from mongodb/openapi repository
+# This ensures agents have access to the latest IPA validation documentation
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCS_EXTERNAL_DIR="$REPO_ROOT/docs/external"
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Updating external documentation...${NC}"
+
+# Create docs/external directory if it doesn't exist
+mkdir -p "$DOCS_EXTERNAL_DIR"
+
+# Fetch IPA Validation README from mongodb/openapi
+echo -e "${BLUE}Fetching IPA Validation README...${NC}"
+curl -s https://raw.githubusercontent.com/mongodb/openapi/main/tools/spectral/ipa/README.md \
+  -o "$DOCS_EXTERNAL_DIR/ipa-validation-README.md.tmp"
+
+# Add header note about auto-sync
+cat > "$DOCS_EXTERNAL_DIR/ipa-validation-README.md" << 'EOF'
+# IPA Validation
+
+> **Note**: This file is automatically synced from the [mongodb/openapi repository](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/README.md).
+> To update this file, run `./scripts/update-external-docs.sh` from the repository root.
+
+EOF
+
+# Append the fetched content (skip the first line which is the title)
+tail -n +2 "$DOCS_EXTERNAL_DIR/ipa-validation-README.md.tmp" >> "$DOCS_EXTERNAL_DIR/ipa-validation-README.md"
+
+# Clean up temp file
+rm "$DOCS_EXTERNAL_DIR/ipa-validation-README.md.tmp"
+
+echo -e "${GREEN}✓ Updated: docs/external/ipa-validation-README.md${NC}"
+echo -e "${GREEN}External documentation updated successfully!${NC}"
+


### PR DESCRIPTION
**Jira**: CLOUDP-361645

## Overview

This PR adds comprehensive AI agent guidelines and supporting infrastructure to help AI agents (Augment, Claude, GitHub Copilot, etc.) effectively apply IPA guidelines when assisting developers with API design, code reviews, and implementation.

## Motivation

Based on 6-7 engagements with API champions, I've developed a workflow where:
- Technical API design documents are exported to markdown in a local workspace
- AI agents reference IPA guidelines to validate designs and suggest alternatives
- I can simulate OpenAPI changes and rely on spectral validation for IPA checks

This infrastructure significantly improved agent efficiency and accuracy during API design evaluations.

## What's Included

### 1. Agent Guidelines (`agents.md`)
Comprehensive documentation for AI agents covering:
- How to interpret and apply IPA guidelines
- Citation formats and best practices
- Integration with Spectral validation
- 5 detailed workflow examples with prompts
- Quick reference guide for common IPAs

### 2. API Designs Workspace (`api-designs/`)
- Local workspace folder for API design documents
- Structured approach:  `design-notes.md`, `ipa-compliance.md`
- Git-ignored to keep work-in-progress designs local
- README with usage guidance

### 3. External Documentation Sync
- Local copy of Spectral IPA validation rules (`docs/external/`)
- Update script to sync latest validation documentation
- Clarifies IPA implementation details and improves agent understanding

### 4. Contributing Guidelines Update
- Added section on working with AI agents
- Documentation for the API designs workspace
- Instructions for updating external docs

## Usage

**For API Champions/Reviewers:**
- Reference `agents.md` when working with AI agents on API designs
- Use `api-designs/` folder as a workspace for design reviews

**For API Creators in future**
- Can adopt this workflow for their own API design process once proven during review

## Status

Adding this as an **experimental feature** for team evaluation. We can remove it if not proven.