### PR TITLE
chore: Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+    commit-message:
+      prefix: "chore"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable automated dependency updates
- Covers `npm` packages and `github-actions` ecosystems
- Runs weekly on Tuesdays with `chore` commit prefix

## Test plan
- [ ] Verify Dependabot picks up the config and opens PRs after merge