### PR TITLE
feat(ipa0107): Clarify PATCH/PUT behaviour and no-op updates

### DIFF
--- a/ipa/general/0107.md
+++ b/ipa/general/0107.md
@@ -57,8 +57,8 @@ resource.
     **must not** cause
 - The response status code **should** be
   [`200 OK`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200)
-  - If the request is empty, the Update method **should** return a 200 response
-    with no change to the resource
+  - If the request for a _partial_ update is empty, the Update method **should**
+    return a 200 response with no change to the resource
 - Resources **should** provide a single canonical update operation
   - If a resource has multiple Update methods, it's possible one, or all of
     them, **may** be [custom methods](0109.md)

--- a/ipa/general/0107.md
+++ b/ipa/general/0107.md
@@ -35,13 +35,30 @@ resource.
         include fields with `readOnly: true`
 - The response body **should** be the same resource returned by the
   [Get method](0104.md)
-  - The Update method should return the complete resource to avoid complexities
-    for clients
+  - The Update method **should** return the complete resource to avoid
+    complexities for clients
+- The Update method **must** respect the client provided values, or lack
+  thereof, for all fields in the request (see
+  [Client-owned fields](0111.md#single-owner-fields))
+  - For partial resource updates, the Update method **must** only update fields
+    included in the request body and leave all other fields unchanged
+  - For full resource replacements, the Update method **must** update the full
+    resource to match the request
+    - Any fields not included in the request body **must** be unset or set to
+      their default value(s)
+  - If the client explicitly provides `null` for an optional field in the
+    request, the server **should** unset the field or reset it to its default
+    value
+    - The server **should** return a
+      [validation error](0114.md#validation-errors) if the client provides
+      `null` for a field that is not nullable and cannot be unset
 - Update operations **must not** accept query parameters
   - Query parameters are usually a sign of a side effect that standard methods
     **must not** cause
 - The response status code **should** be
   [`200 OK`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200)
+  - If the request is empty, the Update method **should** return a 200 response
+    with no change to the resource
 - Resources **should** provide a single canonical update operation
   - If a resource has multiple Update methods, it's possible one, or all of
     them, **may** be [custom methods](0109.md)


### PR DESCRIPTION
Adds clarification to IPA 107 - Update Method on the behaviour of unset/set/null values for partial updates and full resource replacement.

Also adds note that a partial update operation with no fields provided in the request is a successful no-op.

Ticket: [CLOUDP-396582](https://jira.mongodb.org/browse/CLOUDP-396582)