### PR TITLE
feat: Clarify 124 and 123 to respect client-owned enums and repeated fields

### DIFF
--- a/ipa/general/0123.md
+++ b/ipa/general/0123.md
@@ -26,8 +26,8 @@ the expectation for that data field.
 - The API **must not** accept invalid enum values and silently modify them to
   make them valid. Instead, the API should return a validation error (see
   [Validation Errors](0114.md#validation-errors))
-  - For example, accepting the value `open` if the allowed values are `OPEN` and
-    `CLOSED`
+  - For example, accepting the client-provided value `open` but returning the
+    value `OPEN`
 
 Example:
 

--- a/ipa/general/0123.md
+++ b/ipa/general/0123.md
@@ -23,6 +23,9 @@ the expectation for that data field.
 - API producers **should** use a string field if allowable enum values change
   often or exceed **20**
   - If so, API producers **must** document the allowable values.
+- The API **must not** accept invalid enum values and silently modify them to 
+  make them valid. Instead, the API should return a validation error (see [Validation Errors](0114.md#validation-errors))
+  - For example, accepting the value `open` if the allowed values are `OPEN` and `CLOSED`
 
 Example:
 

--- a/ipa/general/0123.md
+++ b/ipa/general/0123.md
@@ -23,9 +23,11 @@ the expectation for that data field.
 - API producers **should** use a string field if allowable enum values change
   often or exceed **20**
   - If so, API producers **must** document the allowable values.
-- The API **must not** accept invalid enum values and silently modify them to 
-  make them valid. Instead, the API should return a validation error (see [Validation Errors](0114.md#validation-errors))
-  - For example, accepting the value `open` if the allowed values are `OPEN` and `CLOSED`
+- The API **must not** accept invalid enum values and silently modify them to
+  make them valid. Instead, the API should return a validation error (see
+  [Validation Errors](0114.md#validation-errors))
+  - For example, accepting the value `open` if the allowed values are `OPEN` and
+    `CLOSED`
 
 Example:
 

--- a/ipa/general/0124.md
+++ b/ipa/general/0124.md
@@ -19,8 +19,7 @@ reduced when clients need to modify the lists.
     sub-resource instead
 - [Client-owned](0111.md#single-owner-fields) repeated fields **should** be
   respected by the server
-  - The server **must not** modify the provided list by sorting it
-  - The server **should not** modify the provided list by removing duplicates,
+  - The server **should not** modify the order of elements or remove duplicates,
     without explicit documentation that the server will do so
 
 ## Update Strategy

--- a/ipa/general/0124.md
+++ b/ipa/general/0124.md
@@ -17,6 +17,10 @@ reduced when clients need to modify the lists.
   - A good rule of thumb is 100 elements
   - If repeated data has the chance of being too large, the API **should** use a
     sub-resource instead
+- [Client-owned](0111.md#single-owner-fields) repeated fields **should** be respected by the server
+  - The server **must not** modify the provided list by sorting it
+  - The server **should not** modify the provided list by removing duplicates, without explicit
+    documentation that the server will do so
 
 ## Update Strategy
 

--- a/ipa/general/0124.md
+++ b/ipa/general/0124.md
@@ -17,10 +17,11 @@ reduced when clients need to modify the lists.
   - A good rule of thumb is 100 elements
   - If repeated data has the chance of being too large, the API **should** use a
     sub-resource instead
-- [Client-owned](0111.md#single-owner-fields) repeated fields **should** be respected by the server
+- [Client-owned](0111.md#single-owner-fields) repeated fields **should** be
+  respected by the server
   - The server **must not** modify the provided list by sorting it
-  - The server **should not** modify the provided list by removing duplicates, without explicit
-    documentation that the server will do so
+  - The server **should not** modify the provided list by removing duplicates,
+    without explicit documentation that the server will do so
 
 ## Update Strategy
 


### PR DESCRIPTION
Clarifies guidance for enums and repeated fields that the server must respect the client owned value:
- The server should not re-order lists or remove list duplicates, unless documented
- The server must not accept invalid enum values, for example lower-case values and make them upper-case

Ticket: [CLOUDP-398214](https://jira.mongodb.org/browse/CLOUDP-398214)