### PR TITLE
feat: Rule and RulesSection components with Zod validation

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -5,6 +5,7 @@ import type {
 } from "@docusaurus/preset-classic";
 import { themes } from "prism-react-renderer";
 import parseFrontMatter from "./src/plugins/parseIpaFrontMatter";
+import validateIpaRules from "./src/plugins/validateIpaRules";
 
 const config: Config = {
   title: "IPA - Improvement Proposal for APIs",
@@ -36,6 +37,7 @@ const config: Config = {
   },
 
   plugins: [
+    validateIpaRules,
     [
       require.resolve("@easyops-cn/docusaurus-search-local"),
       {

--- a/ipa/_test/demo-rules.mdx
+++ b/ipa/_test/demo-rules.mdx
@@ -1,0 +1,88 @@
+---
+id: 9999
+state: adopt
+draft: true
+---
+
+import { RulesSection, Rule } from '@site/src/components/ipa';
+
+# Demo: Rule Component
+
+This is a test page to demonstrate the Rule component framework. It is not a real IPA document.
+
+## Guidance
+
+This page showcases the different Rule component configurations: lintable vs not-lintable, informational, effort levels, dependencies, and state overrides.
+
+<RulesSection state="adopt">
+
+<Rule
+  id="IPA-9999-must-demo-lintable"
+  given="spec"
+  lintable
+>
+
+A lintable rule targeting the full spec. Lintable rules can be enforced automatically by Spectral.
+
+</Rule>
+
+<Rule
+  id="IPA-9999-must-demo-semantic"
+  given="schema"
+>
+
+A semantic (not lintable) rule targeting schemas. These require human review because the evaluation involves judgement.
+
+</Rule>
+
+<Rule
+  id="IPA-9999-should-demo-effort-reason"
+  given="operation"
+  effort="reason"
+>
+
+A rule with "reason" effort level, meaning it requires reasoning about the API design to evaluate.
+
+</Rule>
+
+<Rule
+  id="IPA-9999-may-demo-informational"
+  informational
+>
+
+An informational rule — no `given` is required because it provides guidance rather than a checkable constraint.
+
+</Rule>
+
+<Rule
+  id="IPA-9999-must-demo-array-given"
+  given={["delete-operation", "$.components.schemas..properties"]}
+  lintable
+  implementation
+>
+
+A lintable rule with multiple `given` targets (alias + JSONPath) and an implementation flag.
+
+</Rule>
+
+<Rule
+  id="IPA-9999-must-demo-dependency"
+  given="paths"
+  dependsOn={["IPA-9999-must-demo-lintable"]}
+>
+
+A rule that depends on another rule, showing the dependency link footer.
+
+</Rule>
+
+<Rule
+  id="IPA-9999-should-demo-state-override"
+  given="resource"
+  state="experimental"
+>
+
+A rule with an explicit state override — shows an extra state badge because it differs from the section's "adopt" state.
+
+</Rule>
+
+</RulesSection>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@docusaurus/plugin-content-docs": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",
         "@docusaurus/theme-classic": "^3.8.1",
-        "@docusaurus/theme-search-algolia": "^3.8.1",
         "@easyops-cn/docusaurus-search-local": "^0.51.1",
         "zod": "^4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@docusaurus/plugin-content-docs": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-classic": "^3.8.1",
-    "@docusaurus/theme-search-algolia": "^3.8.1",
     "@easyops-cn/docusaurus-search-local": "^0.51.1",
     "zod": "^4.3.6"
   }

--- a/src/components/ipa/IpaMetadata/index.tsx
+++ b/src/components/ipa/IpaMetadata/index.tsx
@@ -1,25 +1,31 @@
 import React from "react";
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import type { IpaState } from "@site/src/types/ipa";
+import { ipaStateSchema } from "@site/src/types/ipa";
 import styles from "./IpaMetadata.module.css";
 import Badge, { type BadgeColor } from "../../ui/Badge";
-import type { IpaState } from "../../../types/ipa";
 
 const STATE_CONFIG: Record<IpaState, { label: string; color: BadgeColor }> = {
   adopt: { label: "Adopt", color: "green" },
   experimental: { label: "Experimental", color: "amber" },
-  deprecated: { label: "Deprecated", color: "red" },
+  deprecated: { label: "Deprecated", color: "orange" },
   retired: { label: "Retired", color: "muted" },
 };
 
+/**
+ * Tag strip rendered above the page title for every IPA document.
+ * Reads `state` from the page's frontmatter via `useDoc()` — no props needed.
+ */
 export default function IpaMetadata(): React.ReactElement | null {
   const { frontMatter } = useDoc();
 
-  const state = (frontMatter as Record<string, unknown>).state as
-    | IpaState
-    | undefined;
-  if (!state || !(state in STATE_CONFIG)) return null;
+  const raw = (frontMatter as Record<string, unknown>).state;
+  const parsed = ipaStateSchema.safeParse(typeof raw === "string" ? raw.toLowerCase() : raw);
+  if (!parsed.success) return null;
+  const normalizedState = parsed.data;
+  const stateConfig = STATE_CONFIG[normalizedState];
 
-  const stateConfig = STATE_CONFIG[state];
+  if (!stateConfig) return null;
 
   return (
     <div className={styles.pageMeta}>

--- a/src/components/ipa/Rule/Rule.module.css
+++ b/src/components/ipa/Rule/Rule.module.css
@@ -1,0 +1,114 @@
+.rule {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.25rem;
+  background: var(--ifm-background-surface-color);
+  counter-increment: rule-counter;
+}
+
+.ruleInformational {
+  opacity: 0.8;
+}
+
+.ruleHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+/* Rule number circle — filled by CSS counter, no JS needed */
+.ruleNumber {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--ifm-color-primary);
+  color: var(--mongodb-slate, #001e2b);
+  font-size: 0.8rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.ruleNumber::before {
+  content: counter(rule-counter);
+}
+
+.ruleBadges {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.badgeSeparator {
+  color: var(--ifm-color-emphasis-400);
+  font-size: 0.7rem;
+  user-select: none;
+}
+
+.badgeType {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.spectralLink {
+  font-size: 0.7rem;
+  color: var(--ifm-color-emphasis-600);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  transition: color 0.15s ease;
+}
+.spectralLink:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.ruleBody {
+  padding-left: 2.5rem;
+}
+
+.ruleBody p:first-child {
+  margin-top: 0;
+}
+
+.ruleFooter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-left: 2.5rem;
+  margin-top: 0.75rem;
+}
+
+.ruleDependencies {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0 0 2.5rem;
+  font-size: 0.78rem;
+}
+
+.dependencyLabel {
+  color: var(--ifm-color-emphasis-600);
+  font-weight: 500;
+}
+
+.dependencyLink {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.74rem;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.dependencyLink:hover {
+  text-decoration: underline;
+}

--- a/src/components/ipa/Rule/index.tsx
+++ b/src/components/ipa/Rule/index.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+import { useRulesSection } from "../RulesSection";
+import { rulePropsSchema } from "@site/src/types/ipa";
+import type { IpaState, RuleProps } from "@site/src/types/ipa";
+import styles from "./Rule.module.css";
+import Badge, { type BadgeColor } from "../../ui/Badge";
+
+const SPECTRAL_BASE_URL =
+  "https://github.com/mongodb/openapi/tree/main/tools/spectral";
+
+/** Tag color for each rule-level state badge. */
+const STATE_TAG_COLOR: Partial<Record<IpaState, BadgeColor>> = {
+  experimental: "amber",
+  deprecated: "orange",
+  retired: "muted",
+};
+
+function deriveSpectralRuleId(id: string): string {
+  return `xgen-${id}`;
+}
+
+interface RuleComponentProps extends RuleProps {
+  children: React.ReactNode;
+}
+
+/**
+ * One atomic API design rule with machine-readable metadata.
+ */
+export default function Rule({
+  id,
+  given,
+  lintable = false,
+  informational = false,
+  implementation = false,
+  effort = "check",
+  state: explicitState,
+  dependsOn,
+  children,
+}: RuleComponentProps) {
+  const { state: sectionState } = useRulesSection();
+
+  // Validate props with Zod — throws during SSR to fail the build on invalid props
+  if (typeof window === "undefined") {
+    const validated = rulePropsSchema.safeParse({
+      id,
+      given,
+      lintable,
+      informational,
+      implementation,
+      effort,
+      state: explicitState,
+      dependsOn,
+    });
+    if (!validated.success) {
+      const issues = validated.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ");
+      throw new Error(`<Rule id="${id}">: invalid props — ${issues}`);
+    }
+  }
+
+  const effectiveState: IpaState = explicitState || sectionState || "experimental";
+  const spectralRuleId = lintable ? deriveSpectralRuleId(id) : null;
+
+  // Only show a state badge when the rule diverges from its section's state
+  const showStateBadge = Boolean(
+    explicitState && explicitState !== sectionState,
+  );
+
+  const evaluationType = informational
+    ? "Informational"
+    : lintable
+      ? "Syntactic"
+      : "Semantic";
+
+  return (
+    <div
+      className={`${styles.rule} ${informational ? styles.ruleInformational : ""}`}
+      id={id}
+    >
+      <div className={styles.ruleHeader}>
+        {/* Number is rendered by CSS counter(rule-counter) — no JS needed */}
+        <span className={styles.ruleNumber} aria-hidden="true" />
+
+        <div className={styles.ruleBadges}>
+          {informational ? (
+            <Badge color="blue">Informational</Badge>
+          ) : lintable ? (
+            <Badge color="green">Lintable</Badge>
+          ) : (
+            <Badge color="amber">Not Lintable</Badge>
+          )}
+
+          <span className={styles.badgeSeparator} aria-hidden="true">
+            ·
+          </span>
+          <span className={styles.badgeType}>{evaluationType}</span>
+
+          {lintable && spectralRuleId && (
+            <>
+              <span className={styles.badgeSeparator} aria-hidden="true">
+                ·
+              </span>
+              <a
+                href={SPECTRAL_BASE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.spectralLink}
+              >
+                Spectral rule ↗
+              </a>
+            </>
+          )}
+
+          {implementation && !informational && (
+            <>
+              <span className={styles.badgeSeparator} aria-hidden="true">
+                ·
+              </span>
+              <Badge color="muted">+ Code</Badge>
+            </>
+          )}
+
+          {showStateBadge && (
+            <>
+              <span className={styles.badgeSeparator} aria-hidden="true">
+                ·
+              </span>
+              <Badge color={STATE_TAG_COLOR[effectiveState] ?? "muted"}>
+                {effectiveState}
+              </Badge>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.ruleBody}>{children}</div>
+
+      {!informational && effort !== "check" && (
+        <div className={styles.ruleFooter}>
+          <Badge color={effort === "explore" ? "red" : "amber"}>
+            Effort: {effort}
+          </Badge>
+        </div>
+      )}
+
+      {dependsOn && dependsOn.length > 0 && (
+        <div className={styles.ruleDependencies}>
+          <span className={styles.dependencyLabel}>Depends on:</span>
+          {dependsOn.map((depId) => (
+            <a key={depId} href={`#${depId}`} className={styles.dependencyLink}>
+              {depId}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ipa/RulesSection/RulesSection.module.css
+++ b/src/components/ipa/RulesSection/RulesSection.module.css
@@ -1,0 +1,27 @@
+.rulesSection {
+  margin: 2rem 0;
+  /* CSS counter: each .rule increments this automatically */
+  counter-reset: rule-counter;
+}
+
+.rulesSectionTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.rulesSectionIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 6px;
+  background: var(--ifm-color-primary);
+  color: var(--mongodb-slate, #001e2b);
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-family: monospace;
+}

--- a/src/components/ipa/RulesSection/index.tsx
+++ b/src/components/ipa/RulesSection/index.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext } from "react";
+import type { IpaState } from "@site/src/types/ipa";
+import styles from "./RulesSection.module.css";
+
+interface RulesSectionContextValue {
+  state: IpaState;
+}
+
+const RulesSectionContext = createContext<RulesSectionContextValue | null>(null);
+
+export function useRulesSection(): RulesSectionContextValue {
+  const ctx = useContext(RulesSectionContext);
+  if (!ctx) {
+    throw new Error("<Rule> must be rendered inside a <RulesSection>");
+  }
+  return ctx;
+}
+
+interface RulesSectionProps {
+  state?: IpaState;
+  children: React.ReactNode;
+}
+
+/**
+ * Groups all Rules belonging to one logical section of an IPA document.
+ * Provides the section-level `state` via React context so individual
+ * `<Rule>` components can inherit it without repeating the prop.
+ */
+export default function RulesSection({ state = "adopt", children }: RulesSectionProps) {
+  return (
+    <RulesSectionContext.Provider value={{ state }}>
+      <div className={styles.rulesSection}>
+        <h2 className={styles.rulesSectionTitle}>
+          <span className={styles.rulesSectionIcon} aria-hidden="true">
+            {"<>"}
+          </span>{" "}
+          Rules
+        </h2>
+        {children}
+      </div>
+    </RulesSectionContext.Provider>
+  );
+}

--- a/src/components/ipa/index.ts
+++ b/src/components/ipa/index.ts
@@ -1,0 +1,8 @@
+export { default as RulesSection } from "./RulesSection";
+export { default as Rule } from "./Rule";
+// IpaMetadata is consumed by the DocItem/Content swizzle automatically;
+// exported here for direct use if ever needed.
+export { default as IpaMetadata } from "./IpaMetadata";
+
+// Badge lives in ui/ since it is a generic primitive, not IPA-specific.
+export { default as Badge } from "../ui/Badge";

--- a/src/components/ui/Badge/Badge.module.css
+++ b/src/components/ui/Badge/Badge.module.css
@@ -41,7 +41,27 @@
   color: #e6ac00;
 }
 
-/* red — deprecated */
+/* blue — informational */
+.tag_blue {
+  background: rgba(100, 149, 237, 0.12);
+  color: #2f5db8;
+  border-color: rgba(100, 149, 237, 0.4);
+}
+[data-theme="dark"] .tag_blue {
+  color: #6495ed;
+}
+
+/* orange — deprecated */
+.tag_orange {
+  background: rgba(255, 140, 0, 0.1);
+  color: #904000;
+  border-color: rgba(255, 140, 0, 0.4);
+}
+[data-theme="dark"] .tag_orange {
+  color: #ff8c00;
+}
+
+/* red — explore effort */
 .tag_red {
   background: rgba(255, 100, 100, 0.12);
   color: #b52222;

--- a/src/components/ui/Badge/index.tsx
+++ b/src/components/ui/Badge/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./Badge.module.css";
 
-export type BadgeColor = "green" | "amber" | "red" | "muted";
+export type BadgeColor = "green" | "amber" | "blue" | "orange" | "red" | "muted";
 
 interface BadgeProps {
   color?: BadgeColor;
@@ -14,9 +14,16 @@ export default function Badge({
   dot = false,
   children,
 }: BadgeProps): React.ReactElement {
-  const colorClass = styles[`tag_${color}`] ?? styles.tag_muted;
+  const COLOR_CLASSES: Record<BadgeColor, string> = {
+    green: styles.tag_green,
+    amber: styles.tag_amber,
+    blue: styles.tag_blue,
+    orange: styles.tag_orange,
+    red: styles.tag_red,
+    muted: styles.tag_muted,
+  };
   return (
-    <span className={`${styles.tag} ${colorClass}`}>
+    <span className={`${styles.tag} ${COLOR_CLASSES[color]}`}>
       {dot && <span className={styles.tagDot} aria-hidden="true" />}
       {children}
     </span>

--- a/src/config/givenAliases.ts
+++ b/src/config/givenAliases.ts
@@ -1,0 +1,23 @@
+/**
+ * Predefined `given` aliases following Spectral's alias pattern.
+ * Maps readable alias names to JSONPath expressions.
+ */
+export const GIVEN_ALIASES: Record<string, string> = {
+  "get-operation": "$.paths[*].get",
+  "create-operation": "$.paths[*].post",
+  "update-operation": "$.paths[*][put,patch]",
+  "delete-operation": "$.paths[*].delete",
+  operation: "$.paths[*][get,put,post,delete,options,head,patch,trace]",
+  resource: "$.paths[*]",
+  paths: "$.paths",
+  schema: "$.components.schemas[*]",
+  parameter: "$.paths..parameters[*]",
+  tag: "$.tags[*]",
+  enum: "$..enum",
+  spec: "$",
+};
+
+/** Check if a value is a known given alias. */
+export function isKnownAlias(value: string): boolean {
+  return value in GIVEN_ALIASES;
+}

--- a/src/plugins/validateIpaRules.test.ts
+++ b/src/plugins/validateIpaRules.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractRuleProps,
+  checkUniqueness,
+  checkReferences,
+  checkNoCycles,
+} from "./validateIpaRules";
+
+describe("extractRuleProps", () => {
+  it("extracts id and given from a simple Rule tag", () => {
+    const mdx = `<Rule id="IPA-0100-must-use-english" given="spec">`;
+    const rules = extractRuleProps(mdx);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("IPA-0100-must-use-english");
+    expect(rules[0].given).toBe("spec");
+  });
+
+  it("extracts given as array", () => {
+    const mdx = `<Rule id="IPA-0100-must-foo" given={["schema", "paths"]}>`;
+    const rules = extractRuleProps(mdx);
+    expect(rules[0].given).toEqual(["schema", "paths"]);
+  });
+
+  it("extracts boolean props", () => {
+    const mdx = `<Rule id="IPA-0100-must-foo" given="spec" lintable implementation>`;
+    const rules = extractRuleProps(mdx);
+    expect(rules[0].lintable).toBe(true);
+    expect(rules[0].implementation).toBe(true);
+  });
+
+  it("extracts informational prop", () => {
+    const mdx = `<Rule id="IPA-0100-may-foo" informational>`;
+    const rules = extractRuleProps(mdx);
+    expect(rules[0].informational).toBe(true);
+  });
+
+  it("extracts effort prop", () => {
+    const mdx = `<Rule id="IPA-0100-must-foo" given="spec" effort="explore">`;
+    const rules = extractRuleProps(mdx);
+    expect(rules[0].effort).toBe("explore");
+  });
+
+  it("extracts dependsOn", () => {
+    const mdx = `<Rule id="IPA-0100-must-foo" given="spec" dependsOn={["IPA-0100-must-bar"]}>`;
+    const rules = extractRuleProps(mdx);
+    expect(rules[0].dependsOn).toEqual(["IPA-0100-must-bar"]);
+  });
+
+  it("extracts multiple rules from one file", () => {
+    const mdx = `
+      <Rule id="IPA-0100-must-a" given="spec">
+      <Rule id="IPA-0100-must-b" given="paths">
+    `;
+    const rules = extractRuleProps(mdx);
+    expect(rules).toHaveLength(2);
+  });
+
+  it("ignores Rule tags inside fenced code blocks", () => {
+    const mdx = `
+Some text before.
+
+\`\`\`mdx
+<Rule id="IPA-0100-must-example" given="spec">
+\`\`\`
+
+<Rule id="IPA-0100-must-real" given="spec">
+    `;
+    const rules = extractRuleProps(mdx);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("IPA-0100-must-real");
+  });
+
+  it("extracts lintable={true} explicit syntax", () => {
+    const mdx = `<Rule id="IPA-0100-must-foo" given="spec" lintable={true}>`;
+    const rules = extractRuleProps(mdx);
+    expect(rules[0].lintable).toBe(true);
+  });
+
+  it("extracts lintable={false} explicit syntax", () => {
+    const mdx = `<Rule id="IPA-0100-must-foo" given="spec" lintable={false}>`;
+    const rules = extractRuleProps(mdx);
+    expect(rules[0].lintable).toBe(false);
+  });
+
+  it("extracts self-closing Rule tags", () => {
+    const mdx = `<Rule id="IPA-0100-must-foo" given="spec" />`;
+    const rules = extractRuleProps(mdx);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("IPA-0100-must-foo");
+    expect(rules[0].given).toBe("spec");
+  });
+
+  it("ignores Rule tags inside JSX comments", () => {
+    const mdx = `{/* <Rule id="IPA-0100-must-foo" given="spec"> */}`;
+    const rules = extractRuleProps(mdx);
+    expect(rules).toHaveLength(0);
+  });
+
+  it("handles multiline Rule tags", () => {
+    const mdx = `<Rule
+    id="IPA-0100-must-foo"
+    given="spec"
+    effort="reason"
+  >`;
+    const rules = extractRuleProps(mdx);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].effort).toBe("reason");
+  });
+});
+
+describe("checkUniqueness", () => {
+  it("passes with unique IDs", () => {
+    const rules = [
+      { id: "IPA-0100-must-a", file: "a.mdx", dependsOn: [] as string[] },
+      { id: "IPA-0100-must-b", file: "b.mdx", dependsOn: [] as string[] },
+    ];
+    expect(() => checkUniqueness(rules)).not.toThrow();
+  });
+
+  it("throws on duplicate IDs", () => {
+    const rules = [
+      { id: "IPA-0100-must-a", file: "a.mdx", dependsOn: [] as string[] },
+      { id: "IPA-0100-must-a", file: "b.mdx", dependsOn: [] as string[] },
+    ];
+    expect(() => checkUniqueness(rules)).toThrow(/duplicate.*IPA-0100-must-a/i);
+  });
+});
+
+describe("checkReferences", () => {
+  it("passes when all dependsOn targets exist", () => {
+    const rules = [
+      { id: "IPA-0100-must-a", file: "a.mdx", dependsOn: [] as string[] },
+      { id: "IPA-0100-must-b", file: "a.mdx", dependsOn: ["IPA-0100-must-a"] },
+    ];
+    expect(() => checkReferences(rules)).not.toThrow();
+  });
+
+  it("throws on unresolved reference", () => {
+    const rules = [
+      { id: "IPA-0100-must-a", file: "a.mdx", dependsOn: ["IPA-0100-must-z"] },
+    ];
+    expect(() => checkReferences(rules)).toThrow(
+      /unresolved.*IPA-0100-must-z/i,
+    );
+  });
+});
+
+describe("checkNoCycles", () => {
+  it("passes with a valid DAG", () => {
+    const rules = [
+      { id: "IPA-0100-must-a", file: "a.mdx", dependsOn: [] as string[] },
+      { id: "IPA-0100-must-b", file: "a.mdx", dependsOn: ["IPA-0100-must-a"] },
+      { id: "IPA-0100-must-c", file: "a.mdx", dependsOn: ["IPA-0100-must-b"] },
+    ];
+    expect(() => checkNoCycles(rules)).not.toThrow();
+  });
+
+  it("throws on direct cycle", () => {
+    const rules = [
+      { id: "IPA-0100-must-a", file: "a.mdx", dependsOn: ["IPA-0100-must-b"] },
+      { id: "IPA-0100-must-b", file: "a.mdx", dependsOn: ["IPA-0100-must-a"] },
+    ];
+    expect(() => checkNoCycles(rules)).toThrow(/cycle/i);
+  });
+
+  it("throws on transitive cycle", () => {
+    const rules = [
+      { id: "IPA-0100-must-a", file: "a.mdx", dependsOn: ["IPA-0100-must-c"] },
+      { id: "IPA-0100-must-b", file: "a.mdx", dependsOn: ["IPA-0100-must-a"] },
+      { id: "IPA-0100-must-c", file: "a.mdx", dependsOn: ["IPA-0100-must-b"] },
+    ];
+    expect(() => checkNoCycles(rules)).toThrow(/cycle/i);
+  });
+
+  it("passes with no dependencies", () => {
+    const rules = [
+      { id: "IPA-0100-must-a", file: "a.mdx", dependsOn: [] as string[] },
+      { id: "IPA-0100-must-b", file: "a.mdx", dependsOn: [] as string[] },
+    ];
+    expect(() => checkNoCycles(rules)).not.toThrow();
+  });
+});

--- a/src/plugins/validateIpaRules.ts
+++ b/src/plugins/validateIpaRules.ts
@@ -1,0 +1,243 @@
+import type { LoadContext, Plugin } from "@docusaurus/types";
+import fs from "fs";
+import path from "path";
+import { rulePropsSchema } from "../types/ipa";
+
+// ---- Regex extractors for <Rule> props from MDX ----
+
+/** Match each <Rule ...> opening tag (multiline). */
+const RULE_TAG_RE = /<Rule\s([\s\S]*?)\/?\s*>/g;
+
+const PROP_EXTRACTORS = {
+  id: /id="([^"]+)"/,
+  given_string: /given="([^"]+)"/,
+  given_array: /given=\{\[([^\]]+)\]\}/,
+  effort: /effort="([^"]+)"/,
+  state: /state="([^"]+)"/,
+  dependsOn: /dependsOn=\{\[([^\]]+)\]\}/,
+};
+
+const BOOL_PROPS = ["lintable", "informational", "implementation"] as const;
+
+/** Parse a JSX string array like `"a", "b"` into string[]. */
+function parseStringArray(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+    .filter(Boolean);
+}
+
+export interface ExtractedRule {
+  id: string;
+  given?: string | string[];
+  lintable?: boolean;
+  informational?: boolean;
+  implementation?: boolean;
+  effort?: string;
+  state?: string;
+  dependsOn?: string[];
+  [key: string]: unknown;
+}
+
+/** Extract Rule props from MDX content using regex. */
+export function extractRuleProps(content: string): ExtractedRule[] {
+  // Strip fenced code blocks so we don't extract <Rule> from examples.
+  const stripped = content.replace(/```[\s\S]*?```/g, '');
+  // Strip JSX comments so we don't extract commented-out <Rule> tags.
+  const withoutComments = stripped.replace(/\{\/\*[\s\S]*?\*\/\}/g, '');
+
+  const rules: ExtractedRule[] = [];
+  let match: RegExpExecArray | null;
+
+  RULE_TAG_RE.lastIndex = 0;
+  while ((match = RULE_TAG_RE.exec(withoutComments)) !== null) {
+    const attrs = match[1];
+    const props: ExtractedRule = { id: "" };
+
+    const idMatch = attrs.match(PROP_EXTRACTORS.id);
+    if (idMatch) props.id = idMatch[1];
+
+    // given (string or array)
+    const givenArrayMatch = attrs.match(PROP_EXTRACTORS.given_array);
+    if (givenArrayMatch) {
+      props.given = parseStringArray(givenArrayMatch[1]);
+    } else {
+      const givenStringMatch = attrs.match(PROP_EXTRACTORS.given_string);
+      if (givenStringMatch) props.given = givenStringMatch[1];
+    }
+
+    const effortMatch = attrs.match(PROP_EXTRACTORS.effort);
+    if (effortMatch) props.effort = effortMatch[1];
+
+    const stateMatch = attrs.match(PROP_EXTRACTORS.state);
+    if (stateMatch) props.state = stateMatch[1];
+
+    const depsMatch = attrs.match(PROP_EXTRACTORS.dependsOn);
+    if (depsMatch) props.dependsOn = parseStringArray(depsMatch[1]);
+
+    // boolean props: bare attribute, ={true}, or ={false}
+    for (const boolProp of BOOL_PROPS) {
+      const explicitRe = new RegExp(`(?:^|\\s)${boolProp}=\\{(true|false)\\}`);
+      const explicitMatch = attrs.match(explicitRe);
+      if (explicitMatch) {
+        props[boolProp] = explicitMatch[1] === "true";
+      } else {
+        const bareRe = new RegExp(`(?:^|\\s)${boolProp}(?:\\s|$)`);
+        if (bareRe.test(attrs)) props[boolProp] = true;
+      }
+    }
+
+    if (props.id) rules.push(props);
+  }
+
+  return rules;
+}
+
+// ---- Cross-file validators ----
+
+export interface RuleEntry {
+  id: string;
+  file: string;
+  dependsOn: string[];
+}
+
+/** Check that all rule IDs are unique across files. */
+export function checkUniqueness(rules: RuleEntry[]): void {
+  const seen = new Map<string, string[]>();
+  for (const rule of rules) {
+    const files = seen.get(rule.id) ?? [];
+    files.push(rule.file);
+    seen.set(rule.id, files);
+  }
+  const dupes = [...seen.entries()].filter(([, files]) => files.length > 1);
+  if (dupes.length > 0) {
+    const msg = dupes
+      .map(
+        ([id, files]) => `  Duplicate rule ID "${id}" in: ${files.join(", ")}`,
+      )
+      .join("\n");
+    throw new Error(`Duplicate rule IDs found:\n${msg}`);
+  }
+}
+
+/** Check that every dependsOn reference resolves to an existing rule. */
+export function checkReferences(rules: RuleEntry[]): void {
+  const knownIds = new Set(rules.map((r) => r.id));
+  const unresolved: string[] = [];
+  for (const rule of rules) {
+    for (const dep of rule.dependsOn) {
+      if (!knownIds.has(dep)) {
+        unresolved.push(
+          `  Rule "${rule.id}" (${rule.file}) depends on unresolved "${dep}"`,
+        );
+      }
+    }
+  }
+  if (unresolved.length > 0) {
+    throw new Error(
+      `Unresolved dependsOn references:\n${unresolved.join("\n")}`,
+    );
+  }
+}
+
+/** Check for cycles using Kahn's algorithm. */
+export function checkNoCycles(rules: RuleEntry[]): void {
+  const inDegree = new Map<string, number>();
+  const adj = new Map<string, string[]>();
+
+  for (const rule of rules) {
+    if (!inDegree.has(rule.id)) inDegree.set(rule.id, 0);
+    if (!adj.has(rule.id)) adj.set(rule.id, []);
+  }
+
+  for (const rule of rules) {
+    for (const dep of rule.dependsOn) {
+      // dep -> rule.id (rule depends on dep, so dep must come first)
+      if (!adj.has(dep)) adj.set(dep, []);
+      adj.get(dep)!.push(rule.id);
+      inDegree.set(rule.id, (inDegree.get(rule.id) ?? 0) + 1);
+    }
+  }
+
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) queue.push(id);
+  }
+
+  let processed = 0;
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    processed++;
+    for (const neighbor of adj.get(node) ?? []) {
+      const newDeg = (inDegree.get(neighbor) ?? 1) - 1;
+      inDegree.set(neighbor, newDeg);
+      if (newDeg === 0) queue.push(neighbor);
+    }
+  }
+
+  if (processed < inDegree.size) {
+    const cycleNodes = [...inDegree.entries()]
+      .filter(([, deg]) => deg > 0)
+      .map(([id]) => id);
+    throw new Error(
+      `Dependency cycle detected among rules: ${cycleNodes.join(", ")}`,
+    );
+  }
+}
+
+// ---- Docusaurus plugin ----
+
+function findMdxFiles(dir: string): string[] {
+  const results: string[] = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findMdxFiles(full));
+    } else if (entry.name.endsWith(".mdx")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+export default function validateIpaRulesPlugin(context: LoadContext): Plugin {
+  return {
+    name: "validate-ipa-rules",
+
+    async loadContent() {
+      const ipaDir = path.join(context.siteDir, "ipa");
+      const mdxFiles = findMdxFiles(ipaDir);
+      const allRules: RuleEntry[] = [];
+
+      for (const file of mdxFiles) {
+        const content = fs.readFileSync(file, "utf-8");
+        const extracted = extractRuleProps(content);
+        const relFile = path.relative(context.siteDir, file);
+
+        for (const props of extracted) {
+          const result = rulePropsSchema.safeParse(props);
+          if (!result.success) {
+            const issues = result.error.issues
+              .map((i) => `${i.path.join(".")}: ${i.message}`)
+              .join("; ");
+            throw new Error(
+              `Invalid <Rule> in ${relFile}: id="${props.id}" — ${issues}`,
+            );
+          }
+          allRules.push({
+            id: props.id,
+            file: relFile,
+            dependsOn: props.dependsOn ?? [],
+          });
+        }
+      }
+
+      checkUniqueness(allRules);
+      checkReferences(allRules);
+      checkNoCycles(allRules);
+
+      return null;
+    },
+  };
+}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,13 +1,21 @@
-import React from "react";
+/**
+ * Swizzle wrapper for @theme/DocItem/Content (wrap mode).
+ *
+ * Injects <IpaPageMeta> above the page title for any doc that declares
+ * a `state` key in its frontmatter. The component reads frontmatter itself
+ * via useDoc(), so individual doc files need no JSX imports.
+ *
+ * DOM position: inside the <article>, before the <div class="markdown"> wrapper,
+ * which places it visually above the h1.
+ */
+import React from "react"; // required for JSX transform in this Docusaurus version
 import Content from "@theme-original/DocItem/Content";
 import type { WrapperProps } from "@docusaurus/types";
 import IpaMetadata from "@site/src/components/ipa/IpaMetadata";
 
 type Props = WrapperProps<typeof Content>;
 
-export default function ContentWithIpaMetadata(
-  props: Props,
-): React.ReactElement {
+export default function ContentWrapper(props: Props): React.ReactElement {
   return (
     <>
       <IpaMetadata />

--- a/src/types/ipa.test.ts
+++ b/src/types/ipa.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { rulePropsSchema, givenValueSchema, ruleIdSchema } from "./ipa";
+
+describe("ruleIdSchema", () => {
+  it("accepts valid IDs", () => {
+    expect(
+      ruleIdSchema.safeParse("IPA-0108-must-use-http-delete").success,
+    ).toBe(true);
+    expect(
+      ruleIdSchema.safeParse("IPA-0101-should-not-mirror-database-schema")
+        .success,
+    ).toBe(true);
+    expect(
+      ruleIdSchema.safeParse("IPA-0101-may-have-sub-resources").success,
+    ).toBe(true);
+  });
+
+  it("rejects IDs without severity keyword", () => {
+    expect(ruleIdSchema.safeParse("IPA-0108-use-http-delete").success).toBe(
+      false,
+    );
+  });
+
+  it("rejects IDs with wrong format", () => {
+    expect(ruleIdSchema.safeParse("RULE-0108-must-foo").success).toBe(false);
+    expect(ruleIdSchema.safeParse("IPA-abc-must-foo").success).toBe(false);
+  });
+});
+
+describe("givenValueSchema", () => {
+  it("accepts known aliases", () => {
+    expect(givenValueSchema.safeParse("delete-operation").success).toBe(true);
+    expect(givenValueSchema.safeParse("spec").success).toBe(true);
+    expect(givenValueSchema.safeParse("schema").success).toBe(true);
+  });
+
+  it("accepts raw JSONPaths starting with $", () => {
+    expect(givenValueSchema.safeParse("$.paths[*].get").success).toBe(true);
+    expect(
+      givenValueSchema.safeParse("$.components.schemas..properties").success,
+    ).toBe(true);
+  });
+
+  it("rejects unknown strings that are not JSONPaths", () => {
+    expect(givenValueSchema.safeParse("foo-bar").success).toBe(false);
+    expect(givenValueSchema.safeParse("paths").success).toBe(true); // "paths" IS an alias
+    expect(givenValueSchema.safeParse("unknown").success).toBe(false);
+  });
+});
+
+describe("rulePropsSchema", () => {
+  const validBase = {
+    id: "IPA-0108-must-use-http-delete",
+    given: "delete-operation",
+  };
+
+  it("accepts minimal valid props", () => {
+    const result = rulePropsSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+  });
+
+  it("applies defaults", () => {
+    const result = rulePropsSchema.parse(validBase);
+    expect(result.lintable).toBe(false);
+    expect(result.informational).toBe(false);
+    expect(result.implementation).toBe(false);
+    expect(result.effort).toBe("check");
+  });
+
+  it("accepts given as array", () => {
+    const result = rulePropsSchema.safeParse({
+      ...validBase,
+      given: ["delete-operation", "schema"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts given as array with mixed aliases and JSONPaths", () => {
+    const result = rulePropsSchema.safeParse({
+      ...validBase,
+      given: ["$.components.schemas..properties", "paths"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts all optional props", () => {
+    const result = rulePropsSchema.safeParse({
+      ...validBase,
+      lintable: true,
+      implementation: true,
+      effort: "explore",
+      state: "experimental",
+      dependsOn: ["IPA-0108-must-use-http-delete"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-informational rule without given", () => {
+    const result = rulePropsSchema.safeParse({
+      id: "IPA-0108-must-use-http-delete",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("allows informational rule without given", () => {
+    const result = rulePropsSchema.safeParse({
+      id: "IPA-0101-may-have-custom-methods",
+      informational: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid effort value", () => {
+    const result = rulePropsSchema.safeParse({
+      ...validBase,
+      effort: "investigate",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate dependsOn entries", () => {
+    const result = rulePropsSchema.safeParse({
+      ...validBase,
+      dependsOn: ["IPA-0108-must-use-http-delete", "IPA-0108-must-use-http-delete"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid dependsOn format", () => {
+    const result = rulePropsSchema.safeParse({
+      ...validBase,
+      dependsOn: ["bad-id-format"],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/types/ipa.ts
+++ b/src/types/ipa.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isKnownAlias } from "../config/givenAliases";
 
 export const ipaStateSchema = z.enum([
   "adopt",
@@ -19,3 +20,54 @@ export const ipaFrontmatterSchema = z.object({
     .transform((s) => s.toLowerCase())
     .pipe(ipaStateSchema),
 });
+
+// ---- Rule component schemas ----
+
+/** A single given value: known alias or JSONPath starting with $ */
+export const givenValueSchema = z.string().check(
+  z.refine((v) => isKnownAlias(v) || v.startsWith("$"), {
+    message: "Must be a known alias or a JSONPath starting with $",
+  }),
+);
+
+/** given prop: single value or non-empty array */
+export const givenSchema = z.union([
+  givenValueSchema,
+  z.array(givenValueSchema).nonempty(),
+]);
+
+/** Rule ID format: IPA-{nnnn}-{must|should|may}-{slug} */
+export const ruleIdSchema = z
+  .string()
+  .regex(
+    /^IPA-\d{4}-(must|should|may)-.+$/,
+    "Rule ID must match IPA-{nnnn}-{must|should|may}-{slug}",
+  );
+
+/** Effort level */
+export const effortSchema = z.enum(["check", "reason", "explore"]);
+
+/** Full Rule component props schema */
+export const rulePropsSchema = z
+  .object({
+    id: ruleIdSchema,
+    given: givenSchema.optional(),
+    lintable: z.boolean().default(false),
+    informational: z.boolean().default(false),
+    implementation: z.boolean().default(false),
+    effort: effortSchema.default("check"),
+    state: ipaStateSchema.optional(),
+    dependsOn: z.array(ruleIdSchema).optional().check(
+      z.refine((arr) => !arr || new Set(arr).size === arr.length, {
+        message: "dependsOn must not contain duplicate rule IDs",
+      }),
+    ),
+  })
+  .check(
+    z.refine((data) => data.informational || data.given !== undefined, {
+      message: "Non-informational rules require a 'given' prop",
+      path: ["given"],
+    }),
+  );
+
+export type RuleProps = z.infer<typeof rulePropsSchema>;


### PR DESCRIPTION
## Summary

- `Rule` and `RulesSection` React components with CSS modules for rendering machine-readable API design rules in IPA documents
- Zod build-time validation for all Rule component props (rule ID format, given aliases/JSONPaths, effort levels, cross-field constraints)
- 12 predefined `given` aliases mapping to JSONPaths, following Spectral's alias pattern
- Cross-file validation Docusaurus plugin (unique rule IDs, dependsOn resolution, cycle detection via Kahn's algorithm)
- Badge expanded with blue (informational) and orange (deprecated) color variants
- Draft demo page (`ipa/_test/demo-rules.mdx`) showcasing all prop combinations — visible in dev mode only

This is the first PR in a series splitting #47. Follow-up PRs will add:
1. Examples + Reasons (Correct/Incorrect blocks with Reason callouts)
2. Workflow (evaluation step accordions)

## Test plan

- [x] `npx vitest run` — 50 tests passing (Zod schemas, cross-file validation, frontmatter parsing)
- [x] `npx docusaurus build` — full build succeeds with validation plugin active
- [x] `npx docusaurus start` — verify demo page renders at `/_test/demo-rules` with all 7 rule variants
- [x] Break a Rule prop in the demo `.mdx` file and verify build fails with clear error message