### PR TITLE
ci: Declare minimum permissions on semantic-commit workflow

### DIFF
--- a/.github/workflows/semantic-commit.yaml
+++ b/.github/workflows/semantic-commit.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   semantic-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Declares `permissions: contents: read, pull-requests: read` at the workflow level on `.github/workflows/semantic-commit.yaml`. `amannn/action-semantic-pull-request` reads the PR title via the pulls API to validate conventional-commit format and reports the result as the workflow's own check status. That needs read on `pull-requests` and nothing else.

Worth declaring explicitly even when the inherited default may already be reasonable: CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) showed a tampered third-party action exfiltrating `GITHUB_TOKEN` from workflow logs and the leaked token retaining whatever scope was issued at the workflow level. A per-workflow cap bounds the runtime authority of every action that runs inside it irrespective of repo or org default, gives drift protection if that default ever widens, and registers with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
