### PR TITLE
refactor(ipa): Move index ownership to <Guidelines> via context

### DIFF
--- a/ipa/dev/component-fixtures.mdx
+++ b/ipa/dev/component-fixtures.mdx
@@ -18,10 +18,9 @@ component-merge PR adds a section here.
 
 ## `<Guidelines>`
 
-`<Guidelines>` is a pure visual container: a card-like wrapper that draws
-separators between its children. It carries no state and imposes no semantics on
-its descendants — `<Guideline>` components inside resolve their own `state`
-independently.
+`<Guidelines>` is an ordered list wrapper for `<Guideline>` components. It
+provides automatic numbering and separators between adjacent guidelines, while
+each `<Guideline>` resolves its own `state` independently.
 
 ### Single child
 
@@ -33,34 +32,62 @@ independently.
     effort="reason"
     given="operation"
   >
-    With a single child, `<Guidelines>` simply wraps it without adding any
-    separators.
+    With a single child, `<Guidelines>` wraps it with automatic numbering
+    without adding separators.
 
     :::info
     It can also have annotations.
     :::
 
   </Guideline>
-  <Guideline
-    id="IPA-9999-should-render-separators"
-    implementation
-    state="experimental"
-    effort="reason"
-    given="operation"
-    dependsOn={["IPA-9999-must-wrap-guidelines"]}
-  >
-    With multiple children, `<Guidelines>` draws separators between each
-    adjacent pair.
-  </Guideline>
 </Guidelines>
 
 ### Multiple children (separator styling)
 
 <Guidelines>
-  <p>First child — appears at the top of the card.</p>
-  <p>Second child — separated from the first by a top border.</p>
-  <p>Third child — separator styling applies between every adjacent pair.</p>
+  <Guideline
+    id="IPA-9999-must-render-first-guideline"
+    lintable
+    state="adopt"
+    effort="check"
+    given="operation"
+  >
+    First guideline appears at the top of the card.
+  </Guideline>
+  <Guideline
+    id="IPA-9999-should-render-second-guideline"
+    implementation
+    state="adopt"
+    effort="reason"
+    given="operation"
+  >
+    Second guideline is separated from the first by a top border.
+  </Guideline>
+  <Guideline
+    id="IPA-9999-may-render-third-guideline"
+    informational
+    state="adopt"
+    effort="explore"
+  >
+    Third guideline shows that separator styling applies between every adjacent
+    pair.
+  </Guideline>
 </Guidelines>
+
+### Standalone `<Guideline>` (no numbering)
+
+A `<Guideline>` rendered outside `<Guidelines>` shows no numbering circle and
+renders as a `<div>` rather than an `<li>`.
+
+<Guideline
+  id="IPA-9999-must-render-standalone"
+  informational
+  state="adopt"
+  effort="check"
+>
+  Without a `<Guidelines>` wrapper, no number badge is shown and no list
+  semantics are applied.
+</Guideline>
 
 ## `<Example>`
 

--- a/src/components/ipa/Guideline/Guideline.module.css
+++ b/src/components/ipa/Guideline/Guideline.module.css
@@ -4,27 +4,35 @@
   gap: 0.75rem;
 }
 
+.numbered {
+  counter-increment: ipa-guideline;
+}
+
 .index {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   width: 1.75rem;
   height: 1.75rem;
-  flex-shrink: 0;
   border-radius: 9999px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1;
   background: rgba(150, 150, 150, 0.1);
   color: var(--ifm-color-emphasis-600);
 }
 
-.container {
+.index::before {
+  content: counter(ipa-guideline);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.content {
   flex: 1;
   min-width: 0;
 }
 
-.content {
+.body {
   font-size: 1rem;
   line-height: 1.625;
 }

--- a/src/components/ipa/Guideline/Guideline.test.tsx
+++ b/src/components/ipa/Guideline/Guideline.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import { Guideline } from "./index";
+import type { Guideline as GuidelineData } from "../../../types/guideline";
+
+vi.mock("@docusaurus/plugin-content-docs/client", () => ({
+  useDoc: () => ({ frontMatter: { id: 1, state: "adopt" } }),
+}));
+
+const minimalGuideline = {
+  id: "IPA-0001-must-test-a",
+  informational: true,
+  lintable: false,
+  implementation: false,
+  effort: "check",
+} satisfies GuidelineData;
+
+describe("<Guideline> standalone", () => {
+  it("renders as a standalone block without a numbering circle", () => {
+    render(<Guideline {...minimalGuideline}>content</Guideline>);
+    const guideline = document.querySelector("[data-guideline-id]");
+
+    expect(guideline?.tagName).toBe("DIV");
+    expect(
+      document.querySelector("[data-guideline-id] [aria-hidden='true']"),
+    ).toBeNull();
+  });
+});

--- a/src/components/ipa/Guideline/index.tsx
+++ b/src/components/ipa/Guideline/index.tsx
@@ -1,30 +1,38 @@
 import { type ReactNode, type ReactElement } from "react";
+import clsx from "clsx";
 import type { Guideline } from "../../../types/guideline";
 import { GuidelineContext } from "../../../hooks/useGuideline";
+import { useIsInsideGuidelines } from "../Guidelines/GuidelinesContext";
 import { GuidelineHeader } from "./GuidelineHeader";
 import { GuidelineFooter } from "./GuidelineFooter";
 import styles from "./Guideline.module.css";
 
 interface GuidelineProps extends Guideline {
-  index?: number;
   children: ReactNode;
 }
 
 export function Guideline({
-  index,
   children,
   ...guideline
 }: GuidelineProps): ReactElement {
+  const isInsideGuidelines = useIsInsideGuidelines();
+  const Root = isInsideGuidelines ? "li" : "div";
+
   return (
     <GuidelineContext.Provider value={{ guideline }}>
-      <div className={styles.root} data-guideline-id={guideline.id}>
-        <div className={styles.index}>{index ?? "·"}</div>
-        <div className={styles.container}>
+      <Root
+        className={clsx(styles.root, isInsideGuidelines && styles.numbered)}
+        data-guideline-id={guideline.id}
+      >
+        {isInsideGuidelines && (
+          <div className={styles.index} aria-hidden="true" />
+        )}
+        <div className={styles.content}>
           <GuidelineHeader />
-          <div className={styles.content}>{children}</div>
+          <div className={styles.body}>{children}</div>
           <GuidelineFooter />
         </div>
-      </div>
+      </Root>
     </GuidelineContext.Provider>
   );
 }

--- a/src/components/ipa/Guidelines/Guidelines.module.css
+++ b/src/components/ipa/Guidelines/Guidelines.module.css
@@ -1,5 +1,6 @@
 .root {
   counter-reset: ipa-guideline;
+  list-style: none;
   margin: 2rem 0;
   padding: 1.5rem;
   border-radius: 0.5rem;
@@ -7,32 +8,10 @@
   background-color: var(--ifm-card-background-color);
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   overflow: hidden;
-  list-style: none;
-  counter-reset: guideline;
 }
 
 .root > * + * {
   border-top: 1px solid var(--ifm-color-emphasis-200);
   padding-top: 1.5rem;
   margin-top: 1.5rem;
-}
-
-.root > li {
-  counter-increment: guideline;
-}
-
-.root > li::before {
-  content: counter(guideline);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  flex-shrink: 0;
-  border-radius: 9999px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1;
-  background: rgba(150, 150, 150, 0.1);
-  color: var(--ifm-color-emphasis-600);
 }

--- a/src/components/ipa/Guidelines/Guidelines.module.css
+++ b/src/components/ipa/Guidelines/Guidelines.module.css
@@ -1,4 +1,5 @@
 .root {
+  counter-reset: ipa-guideline;
   margin: 2rem 0;
   padding: 1.5rem;
   border-radius: 0.5rem;
@@ -6,10 +7,32 @@
   background-color: var(--ifm-card-background-color);
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   overflow: hidden;
+  list-style: none;
+  counter-reset: guideline;
 }
 
 .root > * + * {
   border-top: 1px solid var(--ifm-color-emphasis-200);
   padding-top: 1.5rem;
   margin-top: 1.5rem;
+}
+
+.root > li {
+  counter-increment: guideline;
+}
+
+.root > li::before {
+  content: counter(guideline);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+  background: rgba(150, 150, 150, 0.1);
+  color: var(--ifm-color-emphasis-600);
 }

--- a/src/components/ipa/Guidelines/Guidelines.test.tsx
+++ b/src/components/ipa/Guidelines/Guidelines.test.tsx
@@ -1,30 +1,87 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { Guidelines } from "./index";
+import { Guideline } from "../Guideline";
+import type { Guideline as GuidelineData } from "../../../types/guideline";
+
+vi.mock("@docusaurus/plugin-content-docs/client", () => ({
+  useDoc: () => ({ frontMatter: { id: 1, state: "adopt" } }),
+}));
+
+const minimalGuideline = {
+  id: "IPA-0001-must-test-a",
+  informational: true,
+  lintable: false,
+  implementation: false,
+  effort: "check",
+} satisfies GuidelineData;
 
 describe("<Guidelines>", () => {
-  it("renders its children unchanged", () => {
+  it("renders as an ordered list", () => {
     render(
       <Guidelines>
-        <p data-testid="child">hello</p>
+        <Guideline {...minimalGuideline}>content</Guideline>
       </Guidelines>,
     );
+    const list = screen.getByTestId("guidelines");
 
-    expect(screen.getByTestId("child")).toBeInTheDocument();
-    expect(screen.getByTestId("child")).toHaveTextContent("hello");
+    expect(list.tagName).toBe("OL");
+    expect(list.children).toHaveLength(1);
+    expect(list.children[0].tagName).toBe("LI");
+    expect(screen.getByText("content").closest("li")).toBeInTheDocument();
   });
 
-  it("wraps children in a styled container", () => {
+  it("wraps guidelines in a styled container", () => {
     render(
       <Guidelines>
-        <p data-testid="first">one</p>
-        <p data-testid="second">two</p>
+        <Guideline {...minimalGuideline} id="IPA-0001-must-test-a">
+          one
+        </Guideline>
+        <Guideline {...minimalGuideline} id="IPA-0001-must-test-b">
+          two
+        </Guideline>
       </Guidelines>,
     );
 
     const wrapper = screen.getByTestId("guidelines");
-    expect(wrapper).toContainElement(screen.getByTestId("first"));
-    expect(wrapper).toContainElement(screen.getByTestId("second"));
+    expect(
+      wrapper.querySelector("[data-guideline-id='IPA-0001-must-test-a']"),
+    ).toBeInTheDocument();
+    expect(
+      wrapper.querySelector("[data-guideline-id='IPA-0001-must-test-b']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a circle for each <Guideline> child", () => {
+    render(
+      <Guidelines>
+        <Guideline {...minimalGuideline} id="IPA-0001-must-test-a">
+          first
+        </Guideline>
+        <Guideline {...minimalGuideline} id="IPA-0001-must-test-b">
+          second
+        </Guideline>
+        <Guideline {...minimalGuideline} id="IPA-0001-must-test-c">
+          third
+        </Guideline>
+      </Guidelines>,
+    );
+
+    // One circle per guideline; CSS counter provides the number via ::before.
+    const circles = document.querySelectorAll(
+      "[data-guideline-id] [aria-hidden='true']",
+    );
+    expect(circles).toHaveLength(3);
+  });
+
+  it("renders as an ordered list", () => {
+    render(
+      <Guidelines>
+        <li data-testid="item">item</li>
+      </Guidelines>,
+    );
+
+    expect(screen.getByTestId("guidelines").tagName).toBe("OL");
   });
 });

--- a/src/components/ipa/Guidelines/GuidelinesContext.ts
+++ b/src/components/ipa/Guidelines/GuidelinesContext.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from "react";
+
+const GuidelinesContext = createContext(false);
+
+export const GuidelinesProvider = GuidelinesContext.Provider;
+
+export function useIsInsideGuidelines(): boolean {
+  return useContext(GuidelinesContext);
+}

--- a/src/components/ipa/Guidelines/index.tsx
+++ b/src/components/ipa/Guidelines/index.tsx
@@ -1,17 +1,17 @@
 import { type ReactNode, type ReactElement } from "react";
 import styles from "./Guidelines.module.css";
+import { GuidelinesProvider } from "./GuidelinesContext";
 
 interface GuidelinesProps {
   children: ReactNode;
 }
 
-// Pure visual container for a group of <Guideline> components within one
-// logical section of an IPA document. Renders a card-like wrapper with
-// separators between children.
 export function Guidelines({ children }: GuidelinesProps): ReactElement {
   return (
-    <div className={styles.root} data-testid="guidelines">
-      {children}
-    </div>
+    <GuidelinesProvider value={true}>
+      <ol className={styles.root} data-testid="guidelines">
+        {children}
+      </ol>
+    </GuidelinesProvider>
   );
 }


### PR DESCRIPTION
*Tickets*: [CLOUDP-406096](https://jira.mongodb.org/browse/CLOUDP-406096)

<img width="1005" height="790" alt="Screenshot 2026-06-10 at 15 46 05" src="https://github.com/user-attachments/assets/d0dfc60a-d335-499e-b7de-5b6ac6a539a7" />

`<Guideline>` now reads a boolean context set by `<Guidelines>` to decide whether to render the numbered circle and whether to use `<li>` vs `<div>` as its root element. The number badge only appears inside `<Guidelines>`; a standalone `<Guideline>` renders without it.