### PR TITLE
feat(ipa): Add IPA-130 Dynamic Content Fields

### DIFF
--- a/ipa/general/0130.md
+++ b/ipa/general/0130.md
@@ -1,0 +1,25 @@
+---
+id: 130
+state: experimental
+---
+
+# IPA-130: Dynamic Content Fields
+
+Resource properties that hold a dynamic JSON value — configuration objects,
+filters, metadata, templated payloads — should be modeled as a dynamic object
+type, so that clients and tooling can work with the content natively rather than
+as opaque text. Modeling such a property as a string containing the serialized
+JSON instead pushes serialization concerns onto clients and invites round-trip
+drift, because servers routinely normalize the JSON (whitespace, key ordering,
+reformatting of nested structures). Declarative clients then interpret the
+representation-level difference as state drift.
+
+## Guidance
+
+- Properties whose value is JSON **must** be modeled as a JSON object in
+  requests and responses — never as a string holding the serialized form.
+- When the JSON has a well-defined schema, the API **must** model that schema in
+  the resource definition. Clients, documentation, and tooling benefit from
+  knowing the shape of the content.
+- When the JSON is genuinely dynamic (arbitrary client-provided keys and
+  values), the property **should** be modeled as an object with dynamic keys.


### PR DESCRIPTION
## Summary

Adds **IPA-130: Dynamic Content Fields** (experimental), requiring resource properties whose value is JSON to be modeled as JSON objects rather than as strings containing serialized JSON. String-serialized JSON forces clients to serialize/parse at the edges and produces round-trip drift when servers normalize the content (e.g. `AuditLog.auditFilter`).

Part of the [CLOUDP-356095](https://jira.mongodb.org/browse/CLOUDP-356095) epic. Resolves [CLOUDP-412577](https://jira.mongodb.org/browse/CLOUDP-412577).