### PR TITLE
feat(ipa): Sharpen side-effect prohibition and require object response bodies in IPA-103 and IPA-004

### DIFF
--- a/ipa/general/0004.md
+++ b/ipa/general/0004.md
@@ -48,9 +48,11 @@ To learn more, see [IPA-127](0127.md).
 
 ### Side Effects
 
-Side effects are those operations that may create or update resources unrelated
-to the original request, for example, a create operation that also updates a
-parent resource state.
+Side effects are operations that create, update, or delete resources — or mutate
+[client-owned fields](0111.md#single-owner-fields) of a resource — unrelated to
+the target of the original request. For example, a create operation that also
+updates a parent resource's configuration, or an update on resource X that
+silently rewrites client-owned fields on resource Y.
 
 ### Governing API body
 

--- a/ipa/general/0103.md
+++ b/ipa/general/0103.md
@@ -17,6 +17,15 @@ that a service can perform on behalf of the consumer.
 - Standard methods **must not** cause side effects
   - In such scenarios where a side effect is necessary, a custom method
     **should** be used
+  - A side effect specifically includes mutating
+    [client-owned fields](0111.md#single-owner-fields) of any resource other
+    than the target of the request. The dependent mutation **must** be performed
+    through the dependent resource's own endpoint; if the operation is
+    fundamentally multi-resource by design, it **must** be modeled as a custom
+    method per the rule above.
+  - Side effects limited to read-only or
+    [effective values](0111.md#effective-values) of another resource **may**
+    occur in standard methods.
 - Standard methods **must** guarantee
   [atomicity](https://en.wikipedia.org/wiki/Atomicity_%28database_systems%29)
   - In cases where atomicity cannot be guaranteed, consider in the following
@@ -35,6 +44,19 @@ Selecting a custom method may be valuable for:
 - State management of a resource since they usually carry side effects
 - If atomic modifications are required when adding or removing from repeated
   fields
+
+### Response bodies
+
+- Every endpoint **must** support a versioned JSON content type (e.g.
+  `application/vnd.atlas.YYYY-MM-DD+json`), per [IPA-900](../sdks/0900.md).
+  Additional content types (e.g. `+csv`) **may** be offered alongside JSON.
+- When a response body is returned as a JSON content type, it **must** be a JSON
+  object with a fixed set of named properties at the root.
+  - Top-level arrays, primitives, or objects with dynamic (unknown) keys at the
+    root are prohibited because they cannot be consistently typed by
+    schema-based clients and tooling.
+  - Collections **must** be wrapped in an envelope object per [IPA-110](0110.md)
+    (e.g. `{"results": [...], "links": [...], "totalCount": 42}`).
 
 ### Naming
 


### PR DESCRIPTION
## Summary

Two IPA-103 amendments plus the paired IPA-004 glossary alignment:

- **IPA-103 — side effects.** Mutating client-owned fields of any resource other than the request target is a side effect; the dependent mutation must go through the dependent resource's own endpoint, or be modeled as a custom method when the operation is fundamentally multi-resource. Side effects limited to read-only or effective values of another resource may occur.
- **IPA-103 — Response bodies (new subsection).** Every endpoint must support a versioned JSON content type; JSON response bodies must be objects with a fixed set of named properties at the root (no top-level arrays, primitives, or dynamic keys); collections use the standard envelope.
- **IPA-004 — Side Effects glossary** updated to cover mutating client-owned fields of resources unrelated to the request target.

Part of the [CLOUDP-356095](https://jira.mongodb.org/browse/CLOUDP-356095) epic. Resolves [CLOUDP-412564](https://jira.mongodb.org/browse/CLOUDP-412564).