### PR TITLE
docs: Add local PR preview workflow

### DIFF
--- a/.claude/commands/preview-pr.md
+++ b/.claude/commands/preview-pr.md
@@ -1,0 +1,12 @@
+---
+description:
+  Preview a pull request's rendered IPA docs locally (wraps the preview-ipa
+  skill)
+argument-hint: "<pr-number>"
+---
+
+Preview pull request **$ARGUMENTS** locally using the `preview-ipa` skill: check
+out the PR, start the Docusaurus dev server in the background, and report the
+<http://localhost:3000> URL plus the specific guideline page(s) the PR changes.
+
+If no PR number was given, preview the currently checked-out branch.

--- a/.claude/commands/preview-pr.md
+++ b/.claude/commands/preview-pr.md
@@ -7,7 +7,7 @@ argument-hint: "<pr-number>"
 
 Preview pull request **$ARGUMENTS** locally using the `preview-ipa` skill: check
 out the PR, start the Docusaurus dev server in the background, and report the
-local preview URL (default <http://localhost:3000>) plus the specific guideline
-page(s) the PR changes.
+local preview URL (default <http://localhost:3000/ipa/>) plus the specific
+guideline page(s) the PR changes.
 
 If no PR number was given, preview the currently checked-out branch.

--- a/.claude/commands/preview-pr.md
+++ b/.claude/commands/preview-pr.md
@@ -7,6 +7,7 @@ argument-hint: "<pr-number>"
 
 Preview pull request **$ARGUMENTS** locally using the `preview-ipa` skill: check
 out the PR, start the Docusaurus dev server in the background, and report the
-<http://localhost:3000> URL plus the specific guideline page(s) the PR changes.
+local preview URL (default <http://localhost:3000>) plus the specific guideline
+page(s) the PR changes.
 
 If no PR number was given, preview the currently checked-out branch.

--- a/.claude/skills/preview-ipa/SKILL.md
+++ b/.claude/skills/preview-ipa/SKILL.md
@@ -43,6 +43,10 @@ approving it. This serves the same Docusaurus site CI builds, with hot reload.
 ## Notes
 
 - The dev server hot-reloads, so further edits appear without a restart.
+- If port 3000 is busy (e.g. previewing two PRs at once, or a leftover server),
+  pass a port — `scripts/preview-pr.sh <n> --port 3001` — and report that port
+  in the URLs. Without it, Docusaurus prompts interactively for a new port,
+  which stalls a backgrounded run.
 - For production fidelity (search index + the `onBrokenLinks: "throw"` check CI
   runs), use `npm run docusaurus:build && npm run docusaurus:serve` instead —
   slower, but it matches the CI build exactly.

--- a/.claude/skills/preview-ipa/SKILL.md
+++ b/.claude/skills/preview-ipa/SKILL.md
@@ -1,61 +1,46 @@
 ---
 name: preview-ipa
 description:
-  Preview a pull request's rendered IPA documentation locally. Use when a
-  reviewer or contributor wants to see how guideline changes look before merging
-  — the rendered <Guideline> components, anchors, and admonitions, not just the
-  MDX diff. Triggers on "preview PR <n>", "preview this branch", "see the
-  rendered guidelines", "view the docs for this PR".
+  Use when a reviewer or contributor wants to see how a PR's IPA guideline
+  changes render locally — the <Guideline> components, anchors, and admonitions,
+  not just the MDX diff. Triggers on "preview PR <n>", "preview this branch",
+  "see the rendered guidelines", "view the docs for this PR".
 argument-hint: "<pr-number>"
 ---
 
 # Preview IPA docs for a pull request
 
-Render IPA guideline changes locally so a reviewer can see how a PR looks before
-approving it. This serves the same Docusaurus site CI builds, with hot reload.
+Serve the IPA Docusaurus site locally — the same site CI builds, with hot reload
+— so a reviewer sees how a PR renders before merging.
 
 ## Steps
 
-1. **Decide what to preview.**
-   - If the user gave a PR number, use it.
-   - Otherwise preview the currently checked-out branch.
+1. **Pick the target:** the given PR number, or the current branch if none.
 
-2. **Start the preview** from the repo root, in the **background** (the dev
-   server is long-running and would otherwise block):
+2. **Start the server** from the repo root, in the **background** (it is
+   long-running and would otherwise block):
 
    ```bash
-   scripts/preview-pr.sh <pr-number> --no-open   # omit the number for the current branch
+   scripts/preview-pr.sh <pr-number> --no-open   # no number → current branch
    ```
 
-   `--no-open` stops the backgrounded server from launching a browser tab; add
-   `--port 3001` if 3000 is busy (see Notes). If `gh` is unavailable or the
-   script is missing, fall back to: `gh pr checkout <n>` → `npm ci` (only if
-   deps changed) → `npm run docusaurus:start -- --no-open`.
+   `--no-open` keeps the backgrounded server from opening a browser tab; add
+   `--port <n>` if 3000 is taken (otherwise Docusaurus prompts interactively and
+   stalls). See `scripts/preview-pr.sh --help` for all options. If the script
+   isn't present, run the steps by hand: `gh pr checkout <n>` → `npm ci` →
+   `npm run docusaurus:start -- --no-open`.
 
-3. **Report the URLs.** The site is served under the `/ipa/` base path, so the
-   home is `http://localhost:<port>/ipa/` (default port `3000`, or whatever
-   `--port` you passed). Point the reviewer straight at what changed: list the
-   changed guideline files and map each to its page. A guideline file lives
-   under `ipa/general/`, `ipa/sdks/`, or `ipa/dev/` with a zero-padded name, and
-   renders at `http://localhost:<port>/ipa/<id>`, where `<id>` is its
-   frontmatter `id` (the IPA number, no leading zeros) — e.g.
-   `ipa/general/0101.mdx` (`id: 101`) → <http://localhost:3000/ipa/101>. Get the
-   changed files with `gh pr diff <n> --name-only`, or
-   `git diff --name-only origin/main...HEAD` for the current branch.
+3. **Report the page URLs.** The site is served under `/ipa/`, so a guideline
+   page is `http://localhost:<port>/ipa/<id>` — `<id>` is the IPA number, i.e.
+   the changed file's name without leading zeros (e.g. `ipa/general/0101.mdx` →
+   <http://localhost:3000/ipa/101>). List changed files with
+   `gh pr diff <n> --name-only`.
 
-4. **Stop** the background dev server when the user is done by killing the whole
-   process tree — e.g. `pkill -f docusaurus` — then confirm the port no longer
-   responds. Killing only the launcher can orphan the `node` server and leave
-   the port bound (the "leftover server" the port note warns about).
+4. **Stop** by killing the process tree — `pkill -f docusaurus` — then confirm
+   the port is free. Killing only the launcher orphans the `node` server.
 
 ## Notes
 
-- The dev server hot-reloads, so further edits appear without a restart.
-- If port 3000 is busy (e.g. previewing two PRs at once, or a leftover server),
-  pass a port — `scripts/preview-pr.sh <n> --port 3001` — and report that port
-  in the URLs. Without it, Docusaurus prompts interactively for a new port,
-  which stalls a backgrounded run.
 - For production fidelity (search index + the `onBrokenLinks: "throw"` check CI
-  runs), use `npm run docusaurus:build && npm run docusaurus:serve` instead —
-  slower, but it matches the CI build exactly.
+  runs), use `npm run docusaurus:build && npm run docusaurus:serve` instead.
 - Requires Node.js 22.x / npm 10.x (pinned in `.tool-versions`).

--- a/.claude/skills/preview-ipa/SKILL.md
+++ b/.claude/skills/preview-ipa/SKILL.md
@@ -24,21 +24,26 @@ approving it. This serves the same Docusaurus site CI builds, with hot reload.
    server is long-running and would otherwise block):
 
    ```bash
-   scripts/preview-pr.sh <pr-number>   # omit the number to use the current branch
+   scripts/preview-pr.sh <pr-number> --no-open   # omit the number for the current branch
    ```
 
-   If `gh` is unavailable or the script is missing, fall back to:
-   `gh pr checkout <n>` → `npm ci` (only if deps changed) →
-   `npm run docusaurus:start`.
+   `--no-open` stops the backgrounded server from launching a browser tab; add
+   `--port 3001` if 3000 is busy (see Notes). If `gh` is unavailable or the
+   script is missing, fall back to: `gh pr checkout <n>` → `npm ci` (only if
+   deps changed) → `npm run docusaurus:start -- --no-open`.
 
-3. **Report the URLs.** The site serves at <http://localhost:3000>. Point the
-   reviewer straight at what changed: list the changed guideline files and map
-   each to its page — a file `ipa/<id>.mdx` renders at
-   `http://localhost:3000/<id>` (e.g. `ipa/110.mdx` → `/110`). Get the changed
-   files with `gh pr diff <n> --name-only`, or
-   `git diff --name-only origin/main...HEAD` for the current branch.
+3. **Report the URLs.** The site serves at `http://localhost:<port>` (default
+   `3000`, or whatever `--port` you passed). Point the reviewer straight at what
+   changed: list the changed guideline files and map each to its page — a file
+   `ipa/<id>.mdx` renders at `<base-url>/<id>` (e.g. on the default port,
+   `ipa/110.mdx` → <http://localhost:3000/110>). Get the changed files with
+   `gh pr diff <n> --name-only`, or `git diff --name-only origin/main...HEAD`
+   for the current branch.
 
-4. **Stop** the background dev server when the user is done.
+4. **Stop** the background dev server when the user is done by killing the whole
+   process tree — e.g. `pkill -f docusaurus` — then confirm the port no longer
+   responds. Killing only the launcher can orphan the `node` server and leave
+   the port bound (the "leftover server" the port note warns about).
 
 ## Notes
 

--- a/.claude/skills/preview-ipa/SKILL.md
+++ b/.claude/skills/preview-ipa/SKILL.md
@@ -6,6 +6,7 @@ description:
   — the rendered <Guideline> components, anchors, and admonitions, not just the
   MDX diff. Triggers on "preview PR <n>", "preview this branch", "see the
   rendered guidelines", "view the docs for this PR".
+argument-hint: "<pr-number>"
 ---
 
 # Preview IPA docs for a pull request

--- a/.claude/skills/preview-ipa/SKILL.md
+++ b/.claude/skills/preview-ipa/SKILL.md
@@ -32,13 +32,16 @@ approving it. This serves the same Docusaurus site CI builds, with hot reload.
    script is missing, fall back to: `gh pr checkout <n>` → `npm ci` (only if
    deps changed) → `npm run docusaurus:start -- --no-open`.
 
-3. **Report the URLs.** The site serves at `http://localhost:<port>` (default
-   `3000`, or whatever `--port` you passed). Point the reviewer straight at what
-   changed: list the changed guideline files and map each to its page — a file
-   `ipa/<id>.mdx` renders at `<base-url>/<id>` (e.g. on the default port,
-   `ipa/110.mdx` → <http://localhost:3000/110>). Get the changed files with
-   `gh pr diff <n> --name-only`, or `git diff --name-only origin/main...HEAD`
-   for the current branch.
+3. **Report the URLs.** The site is served under the `/ipa/` base path, so the
+   home is `http://localhost:<port>/ipa/` (default port `3000`, or whatever
+   `--port` you passed). Point the reviewer straight at what changed: list the
+   changed guideline files and map each to its page. A guideline file lives
+   under `ipa/general/`, `ipa/sdks/`, or `ipa/dev/` with a zero-padded name, and
+   renders at `http://localhost:<port>/ipa/<id>`, where `<id>` is its
+   frontmatter `id` (the IPA number, no leading zeros) — e.g.
+   `ipa/general/0101.mdx` (`id: 101`) → <http://localhost:3000/ipa/101>. Get the
+   changed files with `gh pr diff <n> --name-only`, or
+   `git diff --name-only origin/main...HEAD` for the current branch.
 
 4. **Stop** the background dev server when the user is done by killing the whole
    process tree — e.g. `pkill -f docusaurus` — then confirm the port no longer

--- a/.claude/skills/preview-ipa/SKILL.md
+++ b/.claude/skills/preview-ipa/SKILL.md
@@ -43,4 +43,3 @@ Serve the IPA Docusaurus site locally — the same site CI builds, with hot relo
 
 - For production fidelity (search index + the `onBrokenLinks: "throw"` check CI
   runs), use `npm run docusaurus:build && npm run docusaurus:serve` instead.
-- Requires Node.js 22.x / npm 10.x (pinned in `.tool-versions`).

--- a/.claude/skills/preview-ipa/SKILL.md
+++ b/.claude/skills/preview-ipa/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: preview-ipa
+description:
+  Preview a pull request's rendered IPA documentation locally. Use when a
+  reviewer or contributor wants to see how guideline changes look before merging
+  — the rendered <Guideline> components, anchors, and admonitions, not just the
+  MDX diff. Triggers on "preview PR <n>", "preview this branch", "see the
+  rendered guidelines", "view the docs for this PR".
+---
+
+# Preview IPA docs for a pull request
+
+Render IPA guideline changes locally so a reviewer can see how a PR looks before
+approving it. This serves the same Docusaurus site CI builds, with hot reload.
+
+## Steps
+
+1. **Decide what to preview.**
+   - If the user gave a PR number, use it.
+   - Otherwise preview the currently checked-out branch.
+
+2. **Start the preview** from the repo root, in the **background** (the dev
+   server is long-running and would otherwise block):
+
+   ```bash
+   scripts/preview-pr.sh <pr-number>   # omit the number to use the current branch
+   ```
+
+   If `gh` is unavailable or the script is missing, fall back to:
+   `gh pr checkout <n>` → `npm ci` (only if deps changed) →
+   `npm run docusaurus:start`.
+
+3. **Report the URLs.** The site serves at <http://localhost:3000>. Point the
+   reviewer straight at what changed: list the changed guideline files and map
+   each to its page — a file `ipa/<id>.mdx` renders at
+   `http://localhost:3000/<id>` (e.g. `ipa/110.mdx` → `/110`). Get the changed
+   files with `gh pr diff <n> --name-only`, or
+   `git diff --name-only origin/main...HEAD` for the current branch.
+
+4. **Stop** the background dev server when the user is done.
+
+## Notes
+
+- The dev server hot-reloads, so further edits appear without a restart.
+- For production fidelity (search index + the `onBrokenLinks: "throw"` check CI
+  runs), use `npm run docusaurus:build && npm run docusaurus:serve` instead —
+  slower, but it matches the CI build exactly.
+- Requires Node.js 22.x / npm 10.x (pinned in `.tool-versions`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,11 +52,13 @@ npm ci                       # only if dependencies changed
 npm run docusaurus:start
 ```
 
-Either way the site opens at <http://localhost:3000> with hot reload. The dev
-server renders `<Guideline>` components exactly as the production build does, so
-it is the fastest way to confirm an enrichment looks right. A file
-`ipa/<id>.mdx` renders at `http://localhost:3000/<id>` (e.g. `ipa/110.mdx` →
-`/110`).
+Either way the site is served under the `/ipa/` base path, so it opens at
+<http://localhost:3000/ipa/> with hot reload. The dev server renders
+`<Guideline>` components exactly as the production build does, so it is the
+fastest way to confirm an enrichment looks right. A guideline file (e.g.
+`ipa/general/0101.mdx`) renders at `http://localhost:3000/ipa/<id>`, where
+`<id>` is its frontmatter `id` — the IPA number without leading zeros (e.g.
+`101`).
 
 If port 3000 is already in use (for example, previewing two PRs at once), pass
 `--port`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,33 @@ help you understand our development process and requirements.
    npm run docusaurus:build
    ```
 
+## Reviewing a pull request locally
+
+To see how a PR renders the guidelines before approving it, check out the PR
+branch and start the dev server. The helper script does both (it needs the
+[GitHub CLI](https://cli.github.com/)):
+
+```bash
+scripts/preview-pr.sh <pr-number>
+```
+
+Or do it by hand:
+
+```bash
+gh pr checkout <pr-number>
+npm ci                       # only if dependencies changed
+npm run docusaurus:start
+```
+
+Either way the site opens at <http://localhost:3000> with hot reload. The dev
+server renders `<Guideline>` components exactly as the production build does, so
+it is the fastest way to confirm an enrichment looks right. A file
+`ipa/<id>.mdx` renders at `http://localhost:3000/<id>` (e.g. `ipa/110.mdx` →
+`/110`).
+
+> Using Claude Code? The `preview-ipa` skill wraps this flow — just ask it to
+> "preview PR `<number>`".
+
 ## Code Quality
 
 Before submitting your changes, ensure they pass our quality checks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,13 @@ it is the fastest way to confirm an enrichment looks right. A file
 `ipa/<id>.mdx` renders at `http://localhost:3000/<id>` (e.g. `ipa/110.mdx` →
 `/110`).
 
+If port 3000 is already in use (for example, previewing two PRs at once), pass
+`--port`:
+
+```bash
+scripts/preview-pr.sh <pr-number> --port 3001
+```
+
 > Using Claude Code? The `preview-ipa` skill wraps this flow — just ask it to
 > "preview PR `<number>`".
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,36 +36,21 @@ help you understand our development process and requirements.
 
 ## Reviewing a pull request locally
 
-To see how a PR renders the guidelines before approving it, check out the PR
-branch and start the dev server. The helper script does both (it needs the
-[GitHub CLI](https://cli.github.com/)):
+Check out a PR and serve the docs to see how it renders. The helper script does
+both (it needs the [GitHub CLI](https://cli.github.com/)):
 
 ```bash
-scripts/preview-pr.sh <pr-number>
+scripts/preview-pr.sh <pr-number>              # current branch if no number
+scripts/preview-pr.sh <pr-number> --port 3001  # if port 3000 is taken
 ```
 
-Or do it by hand:
+By hand: `gh pr checkout <n>` → `npm ci` (if deps changed) →
+`npm run docusaurus:start`.
 
-```bash
-gh pr checkout <pr-number>
-npm ci                       # only if dependencies changed
-npm run docusaurus:start
-```
-
-Either way the site is served under the `/ipa/` base path, so it opens at
-<http://localhost:3000/ipa/> with hot reload. The dev server renders
-`<Guideline>` components exactly as the production build does, so it is the
-fastest way to confirm an enrichment looks right. A guideline file (e.g.
-`ipa/general/0101.mdx`) renders at `http://localhost:3000/ipa/<id>`, where
-`<id>` is its frontmatter `id` — the IPA number without leading zeros (e.g.
-`101`).
-
-If port 3000 is already in use (for example, previewing two PRs at once), pass
-`--port`:
-
-```bash
-scripts/preview-pr.sh <pr-number> --port 3001
-```
+The site is served under `/ipa/`, so it opens at `http://localhost:<port>/ipa/`
+(default port 3000) with hot reload. A guideline renders at
+`http://localhost:<port>/ipa/<id>`, where `<id>` is the IPA number — the file's
+name without leading zeros (e.g. `ipa/general/0101.mdx` → `/ipa/101`).
 
 > Using Claude Code? The `preview-ipa` skill wraps this flow — just ask it to
 > "preview PR `<number>`".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,6 @@ scripts/preview-pr.sh <pr-number>              # current branch if no number
 scripts/preview-pr.sh <pr-number> --port 3001  # if port 3000 is taken
 ```
 
-By hand: `gh pr checkout <n>` → `npm ci` (if deps changed) →
-`npm run docusaurus:start`.
-
 The site is served under `/ipa/`, so it opens at `http://localhost:<port>/ipa/`
 (default port 3000) with hot reload. A guideline renders at
 `http://localhost:<port>/ipa/<id>`, where `<id>` is the IPA number — the file's

--- a/scripts/preview-pr.sh
+++ b/scripts/preview-pr.sh
@@ -3,13 +3,15 @@
 # Preview a pull request's rendered IPA docs locally.
 #
 # Usage:
-#   scripts/preview-pr.sh <pr-number>   # check out a PR, then serve it
-#   scripts/preview-pr.sh               # serve the currently checked-out branch
-#   scripts/preview-pr.sh <pr> --install  # force a clean `npm ci` first
+#   scripts/preview-pr.sh <pr-number>          # check out a PR, then serve it
+#   scripts/preview-pr.sh                      # serve the current branch
+#   scripts/preview-pr.sh <pr> --port 3001     # serve on a specific port
+#   scripts/preview-pr.sh <pr> --install       # force a clean `npm ci` first
 #
-# Starts the Docusaurus dev server at http://localhost:3000 with hot reload, so
-# you see <Guideline> components rendered exactly as the production build emits
-# them. The <pr-number> form requires the GitHub CLI (`gh`).
+# Starts the Docusaurus dev server (default http://localhost:3000) with hot
+# reload, so you see <Guideline> components rendered exactly as the production
+# build emits them. Pass --port/-p to avoid a clash with port 3000 (e.g. when
+# comparing two PRs side by side). The <pr-number> form requires the GitHub CLI.
 # Prerequisites: Node.js 22.x / npm 10.x (pinned in .tool-versions).
 
 set -euo pipefail
@@ -18,21 +20,37 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 pr=""
+port=""
 force_install=false
-for arg in "$@"; do
-  case "$arg" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     -i | --install) force_install=true ;;
+    -p | --port)
+      shift
+      port="${1:-}"
+      if [[ -z "$port" ]]; then
+        echo "error: --port requires a value" >&2
+        exit 1
+      fi
+      ;;
+    --port=*) port="${1#*=}" ;;
     -h | --help)
-      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     -*)
-      echo "error: unknown option '$arg'" >&2
+      echo "error: unknown option '$1'" >&2
       exit 1
       ;;
-    *) pr="$arg" ;;
+    *) pr="$1" ;;
   esac
+  shift
 done
+
+if [[ -n "$port" && ! "$port" =~ ^[0-9]+$ ]]; then
+  echo "error: --port must be a number (got '$port')" >&2
+  exit 1
+fi
 
 if [[ -n "$pr" ]]; then
   if ! command -v gh >/dev/null 2>&1; then
@@ -53,5 +71,9 @@ else
   echo "==> Reusing existing node_modules (pass --install if dependencies changed)"
 fi
 
-echo "==> Starting Docusaurus dev server at http://localhost:3000 (Ctrl-C to stop)"
-npm run docusaurus:start
+echo "==> Starting Docusaurus dev server at http://localhost:${port:-3000} (Ctrl-C to stop)"
+if [[ -n "$port" ]]; then
+  npm run docusaurus:start -- --port "$port"
+else
+  npm run docusaurus:start
+fi

--- a/scripts/preview-pr.sh
+++ b/scripts/preview-pr.sh
@@ -13,7 +13,7 @@
 # reload, so you see <Guideline> components rendered exactly as the production
 # build emits them. Pass --port/-p to avoid a clash with port 3000 (e.g. when
 # comparing two PRs side by side). The <pr-number> form requires the GitHub CLI.
-# Prerequisites: Node.js 22.x / npm 10.x (pinned in .tool-versions).
+# Prerequisites: the Node and npm versions pinned in .tool-versions.
 
 set -euo pipefail
 

--- a/scripts/preview-pr.sh
+++ b/scripts/preview-pr.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Preview a pull request's rendered IPA docs locally.
+#
+# Usage:
+#   scripts/preview-pr.sh <pr-number>   # check out a PR, then serve it
+#   scripts/preview-pr.sh               # serve the currently checked-out branch
+#   scripts/preview-pr.sh <pr> --install  # force a clean `npm ci` first
+#
+# Starts the Docusaurus dev server at http://localhost:3000 with hot reload, so
+# you see <Guideline> components rendered exactly as the production build emits
+# them. The <pr-number> form requires the GitHub CLI (`gh`).
+# Prerequisites: Node.js 22.x / npm 10.x (pinned in .tool-versions).
+
+set -euo pipefail
+
+# Always operate from the repo root, regardless of the caller's directory.
+cd "$(dirname "$0")/.."
+
+pr=""
+force_install=false
+for arg in "$@"; do
+  case "$arg" in
+    -i | --install) force_install=true ;;
+    -h | --help)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown option '$arg'" >&2
+      exit 1
+      ;;
+    *) pr="$arg" ;;
+  esac
+done
+
+if [[ -n "$pr" ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "error: the GitHub CLI (gh) is required to check out a PR by number." >&2
+    echo "       Install it from https://cli.github.com/, or check the branch out manually." >&2
+    exit 1
+  fi
+  echo "==> Checking out PR #$pr"
+  gh pr checkout "$pr"
+fi
+
+echo "==> Current branch: $(git rev-parse --abbrev-ref HEAD)"
+
+if [[ "$force_install" == true || ! -d node_modules ]]; then
+  echo "==> Installing dependencies (npm ci)"
+  npm ci
+else
+  echo "==> Reusing existing node_modules (pass --install if dependencies changed)"
+fi
+
+echo "==> Starting Docusaurus dev server at http://localhost:3000 (Ctrl-C to stop)"
+npm run docusaurus:start

--- a/scripts/preview-pr.sh
+++ b/scripts/preview-pr.sh
@@ -6,6 +6,7 @@
 #   scripts/preview-pr.sh <pr-number>          # check out a PR, then serve it
 #   scripts/preview-pr.sh                      # serve the current branch
 #   scripts/preview-pr.sh <pr> --port 3001     # serve on a specific port
+#   scripts/preview-pr.sh <pr> --no-open       # don't open a browser tab
 #   scripts/preview-pr.sh <pr> --install       # force a clean `npm ci` first
 #
 # Starts the Docusaurus dev server (default http://localhost:3000) with hot
@@ -22,9 +23,11 @@ cd "$(dirname "$0")/.."
 pr=""
 port=""
 force_install=false
+no_open=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -i | --install) force_install=true ;;
+    --no-open) no_open=true ;;
     -p | --port)
       shift
       port="${1:-}"
@@ -33,9 +36,15 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       ;;
-    --port=*) port="${1#*=}" ;;
+    --port=*)
+      port="${1#*=}"
+      if [[ -z "$port" ]]; then
+        echo "error: --port requires a value" >&2
+        exit 1
+      fi
+      ;;
     -h | --help)
-      sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     -*)
@@ -72,8 +81,15 @@ else
 fi
 
 echo "==> Starting Docusaurus dev server at http://localhost:${port:-3000} (Ctrl-C to stop)"
+start_args=()
 if [[ -n "$port" ]]; then
-  npm run docusaurus:start -- --port "$port"
+  start_args+=(--port "$port")
+fi
+if [[ "$no_open" == true ]]; then
+  start_args+=(--no-open)
+fi
+if [[ ${#start_args[@]} -gt 0 ]]; then
+  npm run docusaurus:start -- "${start_args[@]}"
 else
   npm run docusaurus:start
 fi


### PR DESCRIPTION
## What

Adds a local workflow for previewing how a PR renders the IPA docs before merging — no hosted infrastructure.

- `scripts/preview-pr.sh` — checks out a PR and starts the Docusaurus dev server (supports `--port`, `--no-open`, `--install`).
- `/preview-pr <n>` slash command + a `preview-ipa` Claude Code skill that wrap the script.
- `CONTRIBUTING.md` — a short "Reviewing a pull request locally" section.