### PR TITLE
fix(ipa): Standardize guideline IDs to 3-digit format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,13 +79,13 @@ Introductory prose explaining the section.
 
 <Guidelines>
 
-<Guideline id="IPA-0100-must-use-american-english" given="spec" lintable>
+<Guideline id="IPA-100-must-use-american-english" given="spec" lintable>
 
 API producers **must** use American English across the API.
 
 </Guideline>
 
-<Guideline id="IPA-0100-should-follow-style-guide" given="spec">
+<Guideline id="IPA-100-should-follow-style-guide" given="spec">
 
 API producers **should** follow the MongoDB Style Guide for terminology.
 
@@ -99,7 +99,7 @@ More explanatory prose.
 
 <Guidelines>
 
-<Guideline id="IPA-0100-must-not-use-slang" given="spec">
+<Guideline id="IPA-100-must-not-use-slang" given="spec">
 
 ...
 
@@ -120,13 +120,13 @@ check it from the component alone.
 
 **`id`** (required)
 
-A unique identifier in the format `IPA-{nnnn}-{must|should|may}-{slug}`. The
+A unique identifier in the format `IPA-{nnn}-{must|should|may}-{slug}`. The
 four-digit number is the principle number (zero-padded), and the severity token
 must match the bolded keyword in the prose — `must not` maps to `must`,
 `should not` to `should`.
 
 ```text
-IPA-0104-must-resource-has-get
+IPA-104-must-resource-has-get
      ^^^^  ^^^^  ^^^^^^^^^^^^^^^^
      prin  sev   slug (kebab-case description)
 ```
@@ -191,10 +191,10 @@ sense.
 
 ```mdx
 <Guideline
-  id="IPA-0104-must-resource-has-get"
+  id="IPA-104-must-resource-has-get"
   given="resource"
   lintable
-  dependsOn={["IPA-0101-must-resource-oriented-design"]}
+  dependsOn={["IPA-101-must-resource-oriented-design"]}
 >
 ```
 

--- a/ipa/dev/component-fixtures.mdx
+++ b/ipa/dev/component-fixtures.mdx
@@ -24,7 +24,7 @@ each `<Guideline>` resolves its own `state` independently.
 
 <Guidelines>
   <Guideline
-    id="IPA-9999-must-wrap-guidelines"
+    id="IPA-999-must-wrap-guidelines"
     lintable
     state="adopt"
     effort="reason"
@@ -44,7 +44,7 @@ each `<Guideline>` resolves its own `state` independently.
 
 <Guidelines>
   <Guideline
-    id="IPA-9999-must-render-first-guideline"
+    id="IPA-999-must-render-first-guideline"
     lintable
     state="adopt"
     effort="check"
@@ -53,7 +53,7 @@ each `<Guideline>` resolves its own `state` independently.
     First guideline appears at the top of the card.
   </Guideline>
   <Guideline
-    id="IPA-9999-should-render-second-guideline"
+    id="IPA-999-should-render-second-guideline"
     implementation
     state="adopt"
     effort="reason"
@@ -62,7 +62,7 @@ each `<Guideline>` resolves its own `state` independently.
     Second guideline is separated from the first by a top border.
   </Guideline>
   <Guideline
-    id="IPA-9999-may-render-third-guideline"
+    id="IPA-999-may-render-third-guideline"
     informational
     state="adopt"
     effort="explore"
@@ -78,7 +78,7 @@ A `<Guideline>` rendered outside `<Guidelines>` shows no numbering circle and
 renders as a `<div>` rather than an `<li>`.
 
 <Guideline
-  id="IPA-9999-must-render-standalone"
+  id="IPA-999-must-render-standalone"
   informational
   state="adopt"
   effort="check"
@@ -172,7 +172,7 @@ evaluate the rule. The component renders the same regardless of the guideline's
 metadata.
 
 <Guideline
-  id="IPA-9999-must-use-american-english"
+  id="IPA-999-must-use-american-english"
   state="adopt"
   effort="check"
   given="spec"

--- a/ipa/dev/component-fixtures.mdx
+++ b/ipa/dev/component-fixtures.mdx
@@ -1,5 +1,5 @@
 ---
-id: 9999
+id: 0
 title: "Component fixtures (dev only)"
 sidebar_label: "Dev fixtures"
 draft: true
@@ -24,7 +24,7 @@ each `<Guideline>` resolves its own `state` independently.
 
 <Guidelines>
   <Guideline
-    id="IPA-999-must-wrap-guidelines"
+    id="IPA-000-must-wrap-guidelines"
     lintable
     state="adopt"
     effort="reason"
@@ -44,7 +44,7 @@ each `<Guideline>` resolves its own `state` independently.
 
 <Guidelines>
   <Guideline
-    id="IPA-999-must-render-first-guideline"
+    id="IPA-000-must-render-first-guideline"
     lintable
     state="adopt"
     effort="check"
@@ -53,7 +53,7 @@ each `<Guideline>` resolves its own `state` independently.
     First guideline appears at the top of the card.
   </Guideline>
   <Guideline
-    id="IPA-999-should-render-second-guideline"
+    id="IPA-000-should-render-second-guideline"
     implementation
     state="adopt"
     effort="reason"
@@ -62,7 +62,7 @@ each `<Guideline>` resolves its own `state` independently.
     Second guideline is separated from the first by a top border.
   </Guideline>
   <Guideline
-    id="IPA-999-may-render-third-guideline"
+    id="IPA-000-may-render-third-guideline"
     informational
     state="adopt"
     effort="explore"
@@ -78,7 +78,7 @@ A `<Guideline>` rendered outside `<Guidelines>` shows no numbering circle and
 renders as a `<div>` rather than an `<li>`.
 
 <Guideline
-  id="IPA-999-must-render-standalone"
+  id="IPA-000-must-render-standalone"
   informational
   state="adopt"
   effort="check"
@@ -172,7 +172,7 @@ evaluate the rule. The component renders the same regardless of the guideline's
 metadata.
 
 <Guideline
-  id="IPA-999-must-use-american-english"
+  id="IPA-000-must-use-american-english"
   state="adopt"
   effort="check"
   given="spec"

--- a/ipa/general/0100.mdx
+++ b/ipa/general/0100.mdx
@@ -14,7 +14,7 @@ language.
 
 <Guidelines>
 
-<Guideline id="IPA-0100-must-use-american-english" given="spec" lintable>
+<Guideline id="IPA-100-must-use-american-english" given="spec" lintable>
 
 API producers **must** use American English across the API.
 

--- a/src/components/ipa/Guideline/Guideline.test.tsx
+++ b/src/components/ipa/Guideline/Guideline.test.tsx
@@ -9,7 +9,7 @@ vi.mock("@docusaurus/plugin-content-docs/client", () => ({
 }));
 
 const minimalGuideline = {
-  id: "IPA-0001-must-test-a",
+  id: "IPA-001-must-test-a",
   informational: true,
   lintable: false,
   implementation: false,

--- a/src/components/ipa/Guideline/GuidelineFooter.tsx
+++ b/src/components/ipa/Guideline/GuidelineFooter.tsx
@@ -3,30 +3,30 @@ import { useGuideline } from "../../../hooks/useGuideline";
 import { usePrinciple } from "../../../hooks/usePrinciple";
 import styles from "./GuidelineFooter.module.css";
 
-// IPA-0107-must-use-http-patch → "Use HTTP Patch"
+// IPA-107-must-use-http-patch → "Use HTTP Patch"
 function slugToTitle(id: string): string {
-  const slug = id.replace(/^IPA-\d{4}-(must|should|may)-/, "");
+  const slug = id.replace(/^IPA-\d{3}-(must|should|may)-/, "");
   return slug
     .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
 }
 
-// IPA-0107-must-use-http-patch → 107
+// IPA-107-must-use-http-patch → 107
 function ipaNumber(id: string): number | null {
-  const match = id.match(/^IPA-(\d{4})/);
+  const match = id.match(/^IPA-(\d{3})/);
   return match ? parseInt(match[1], 10) : null;
 }
 
-// "IPA-0107-must-use-http-patch" → "IPA-107: Use HTTP Patch"
+// "IPA-107-must-use-http-patch" → "IPA-107: Use HTTP Patch"
 function depLabel(depId: string): string {
   const num = ipaNumber(depId);
   const title = slugToTitle(depId);
   return num !== null ? `IPA-${num}: ${title}` : title;
 }
 
-// Cross-IPA: /107#IPA-0107-must-use-http-patch
-// Same-IPA:  #IPA-0107-must-use-http-patch
+// Cross-IPA: /107#IPA-107-must-use-http-patch
+// Same-IPA:  #IPA-107-must-use-http-patch
 function depHref(depId: string, currentIpa: number): string {
   const depIpa = ipaNumber(depId);
   const anchor = `#${depId}`;

--- a/src/components/ipa/Guideline/GuidelineHeader.tsx
+++ b/src/components/ipa/Guideline/GuidelineHeader.tsx
@@ -9,7 +9,7 @@ const SPECTRAL_RULESETS_URL =
   "https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets";
 
 function spectralFileUrl(id: string): string {
-  const match = id.match(/^IPA-(\d{4})/);
+  const match = id.match(/^IPA-(\d{3})/);
   if (!match) return SPECTRAL_RULESETS_URL;
   const num = parseInt(match[1], 10);
   return `${SPECTRAL_RULESETS_URL}/IPA-${String(num).padStart(3, "0")}.yaml`;

--- a/src/components/ipa/Guidelines/Guidelines.test.tsx
+++ b/src/components/ipa/Guidelines/Guidelines.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@docusaurus/plugin-content-docs/client", () => ({
 }));
 
 const minimalGuideline = {
-  id: "IPA-0001-must-test-a",
+  id: "IPA-001-must-test-a",
   informational: true,
   lintable: false,
   implementation: false,
@@ -36,10 +36,10 @@ describe("<Guidelines>", () => {
   it("wraps guidelines in a styled container", () => {
     render(
       <Guidelines>
-        <Guideline {...minimalGuideline} id="IPA-0001-must-test-a">
+        <Guideline {...minimalGuideline} id="IPA-001-must-test-a">
           one
         </Guideline>
-        <Guideline {...minimalGuideline} id="IPA-0001-must-test-b">
+        <Guideline {...minimalGuideline} id="IPA-001-must-test-b">
           two
         </Guideline>
       </Guidelines>,
@@ -47,23 +47,23 @@ describe("<Guidelines>", () => {
 
     const wrapper = screen.getByTestId("guidelines");
     expect(
-      wrapper.querySelector("[data-guideline-id='IPA-0001-must-test-a']"),
+      wrapper.querySelector("[data-guideline-id='IPA-001-must-test-a']"),
     ).toBeInTheDocument();
     expect(
-      wrapper.querySelector("[data-guideline-id='IPA-0001-must-test-b']"),
+      wrapper.querySelector("[data-guideline-id='IPA-001-must-test-b']"),
     ).toBeInTheDocument();
   });
 
   it("renders a circle for each <Guideline> child", () => {
     render(
       <Guidelines>
-        <Guideline {...minimalGuideline} id="IPA-0001-must-test-a">
+        <Guideline {...minimalGuideline} id="IPA-001-must-test-a">
           first
         </Guideline>
-        <Guideline {...minimalGuideline} id="IPA-0001-must-test-b">
+        <Guideline {...minimalGuideline} id="IPA-001-must-test-b">
           second
         </Guideline>
-        <Guideline {...minimalGuideline} id="IPA-0001-must-test-c">
+        <Guideline {...minimalGuideline} id="IPA-001-must-test-c">
           third
         </Guideline>
       </Guidelines>,

--- a/src/types/guideline.ts
+++ b/src/types/guideline.ts
@@ -37,12 +37,12 @@ export const givenSchema = z.union([
   z.array(givenValueSchema).nonempty(),
 ]);
 
-// Guideline ID format: IPA-{nnnn}-{must|should|may}-{slug}
+// Guideline ID format: IPA-{nnn}-{must|should|may}-{slug}
 export const guidelineIdSchema = z
   .string()
   .regex(
-    /^IPA-\d{4}-(must|should|may)-.+$/,
-    "Guideline ID must match IPA-{nnnn}-{must|should|may}-{slug}",
+    /^IPA-\d{3}-(must|should|may)-.+$/,
+    "Guideline ID must match IPA-{nnn}-{must|should|may}-{slug}",
   );
 
 // Effort level


### PR DESCRIPTION
## What

Standardizes IPA guideline IDs from 4-digit (`IPA-0100`) to 3-digit (`IPA-100`) format throughout the codebase, aligning with Spectral's ruleset filenames (`IPA-104.yaml`).