### PR TITLE
feat(guideline): Replace lintable/informational flags with enforcement enum

### DIFF
--- a/ipa/dev/component-fixtures.mdx
+++ b/ipa/dev/component-fixtures.mdx
@@ -26,7 +26,7 @@ header — the `informational` field stays in the metadata.
 
 <Guidelines>
 
-<Guideline id="IPA-000-must-use-american-english" given="spec" lintable>
+<Guideline id="IPA-000-must-use-american-english" given="spec" enforcement="rule">
 
 API producers **must** use American English across the API — resource names,
 field names, descriptions, and enum values.
@@ -92,7 +92,7 @@ children and draws separators between them. A `<Guideline>` resolves its own
 <Guidelines>
   <Guideline
     id="IPA-000-must-render-first-guideline"
-    lintable
+    enforcement="rule"
     state="adopt"
     effort="check"
     given="operation"
@@ -101,6 +101,7 @@ children and draws separators between them. A `<Guideline>` resolves its own
   </Guideline>
   <Guideline
     id="IPA-000-should-render-second-guideline"
+    enforcement="automatable"
     implementation
     state="adopt"
     effort="reason"
@@ -110,7 +111,7 @@ children and draws separators between them. A `<Guideline>` resolves its own
   </Guideline>
   <Guideline
     id="IPA-000-may-render-third-guideline"
-    informational
+    enforcement="advisory"
     state="adopt"
     effort="explore"
   >
@@ -126,7 +127,7 @@ renders as a `<div>` rather than an `<li>`.
 
 <Guideline
   id="IPA-000-must-render-standalone"
-  informational
+  enforcement="advisory"
   state="adopt"
   effort="check"
 >

--- a/ipa/general/0100.mdx
+++ b/ipa/general/0100.mdx
@@ -14,7 +14,7 @@ language.
 
 <Guidelines>
 
-<Guideline id="IPA-100-must-use-american-english" given="spec" lintable>
+<Guideline id="IPA-100-must-use-american-english" given="spec" enforcement="rule">
 
 API producers **must** use American English across the API.
 

--- a/src/components/ipa/Guideline/Guideline.test.tsx
+++ b/src/components/ipa/Guideline/Guideline.test.tsx
@@ -10,8 +10,7 @@ vi.mock("@docusaurus/plugin-content-docs/client", () => ({
 
 const minimalGuideline = {
   id: "IPA-001-must-test-a",
-  informational: true,
-  lintable: false,
+  enforcement: "advisory",
   implementation: false,
   effort: "check",
 } satisfies GuidelineData;

--- a/src/components/ipa/Guideline/GuidelineHeader.tsx
+++ b/src/components/ipa/Guideline/GuidelineHeader.tsx
@@ -25,12 +25,12 @@ export function GuidelineHeader(): ReactElement | null {
 
   // Nothing to show → render no header at all, so it doesn't leave an empty
   // bar above the body.
-  if (!stateBadge && !guideline.lintable) return null;
+  if (!stateBadge && guideline.enforcement !== "rule") return null;
 
   return (
     <div className={styles.root}>
       {stateBadge && <div className={styles.badges}>{stateBadge}</div>}
-      {guideline.lintable && (
+      {guideline.enforcement === "rule" && (
         <a
           href={spectralFileUrl(guideline.id)}
           target="_blank"

--- a/src/components/ipa/Guidelines/Guidelines.test.tsx
+++ b/src/components/ipa/Guidelines/Guidelines.test.tsx
@@ -11,8 +11,7 @@ vi.mock("@docusaurus/plugin-content-docs/client", () => ({
 
 const minimalGuideline = {
   id: "IPA-001-must-test-a",
-  informational: true,
-  lintable: false,
+  enforcement: "advisory",
   implementation: false,
   effort: "check",
 } satisfies GuidelineData;

--- a/src/types/guideline.ts
+++ b/src/types/guideline.ts
@@ -48,13 +48,24 @@ export const guidelineIdSchema = z
 // Effort level
 export const effortSchema = z.enum(["check", "reason", "explore"]);
 
+// Enforcement mode:
+// "rule"        — Spectral rule exists and is active; renders a "Lint rule ↗" link
+// "automatable" — automatable check, no Spectral rule yet; renders a "Lint rule pending" badge
+// "review"      — needs agentic review; no lint link
+// "advisory"    — not enforced; context or guiding principle only
+export const enforcementSchema = z.enum([
+  "rule",
+  "automatable",
+  "review",
+  "advisory",
+]);
+
 // Full Guideline component props schema
 export const guidelinePropsSchema = z
   .object({
     id: guidelineIdSchema,
     given: givenSchema.optional(),
-    lintable: z.boolean().default(false),
-    informational: z.boolean().default(false),
+    enforcement: enforcementSchema.default("review"),
     // Metadata consumed by the extraction pipeline and agent skill router, not rendered in the UI.
     implementation: z.boolean().default(false),
     effort: effortSchema.default("check"),
@@ -69,10 +80,13 @@ export const guidelinePropsSchema = z
       ),
   })
   .check(
-    z.refine((data) => data.informational || data.given !== undefined, {
-      message: "Non-informational guidelines require a 'given' prop",
-      path: ["given"],
-    }),
+    z.refine(
+      (data) => data.enforcement === "advisory" || data.given !== undefined,
+      {
+        message: "Non-advisory guidelines require a 'given' prop",
+        path: ["given"],
+      },
+    ),
   );
 
 export type Guideline = z.infer<typeof guidelinePropsSchema>;


### PR DESCRIPTION
## What

Replaces the two boolean props (`lintable`, `informational`) with a single explicit `enforcement` enum field.

## Enforcement values

| Value | Meaning | UI |
|---|---|---|
| `"rule"` | Spectral rule exists and is active | "Lint rule ↗" link |
| `"automatable"` | Automatable check, no rule yet | - |
| `"review"` | Needs agentic review (default) | - |
| `"advisory"` | Not enforced; context only | - |