### PR TITLE
feat(ipa0111): Enrich IPA-111 Server-Modified Values with atomic Guideline components

### DIFF
--- a/ipa/general/0111.mdx
+++ b/ipa/general/0111.mdx
@@ -14,24 +14,311 @@ may modify and return values are complex, not public, and not repeatable.
 
 ### Single Owner Fields
 
+<Guidelines>
+
+<Guideline id="IPA-111-must-have-single-owner" given="schema" enforcement="review" effort="reason">
+
 Fields **must** have a single owner, whether that is the client or the server.
 
 - **Server-owned fields** are fields that are controlled and modified by the
   service
-  - Server-owned fields **must** be documented as read-only
-  - In OpenAPI, server-owned fields **must** have `readOnly: true`
-  - Server-owned fields **must not** be accepted in request bodies for
-    [Create](0106.mdx) or [Update](0107.mdx) operations
-  - Server-owned fields **may** be omitted if appropriate to the API
-    - API Producers **should** document whether the server-owned field is
-      guaranteed, or if it can be omitted in the response
 - **Client-owned fields** are fields that are controlled by the client
-  - All fields that are not explicitly documented as server-owned **must** be
-    considered client-owned
-  - The server **must** respect the value (or lack thereof) of all client-owned
-    fields and not modify them
-  - The server **must** always return the same value the client sent (or absence
-    of value) for client-owned fields
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        clusterName:
+          type: string
+        stateName:
+          type: string
+          readOnly: true
+```
+
+<Example.Reason>
+  `clusterName` is client-owned and mutable, while `stateName` is server-owned
+  and marked `readOnly: true`. Each field has a single, unambiguous owner.
+</Example.Reason>
+
+</Example.Correct>
+
+<Workflow>
+  <Workflow.Step>
+    For each field in the schema, determine whether the client or the server
+    controls its value.
+  </Workflow.Step>
+  <Workflow.Step>
+    Confirm fields are not jointly controlled — a field modified by both the
+    client and the server has no single owner.
+  </Workflow.Step>
+  <Workflow.Step>
+    Flag fields whose ownership is ambiguous or undocumented.
+  </Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
+<Guideline id="IPA-111-must-document-server-owned-read-only" given="schema" enforcement="review" effort="reason">
+
+Server-owned fields **must** be documented as read-only
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        stateName:
+          type: string
+          description: Current state of the cluster, set by the service.
+          readOnly: true
+```
+
+<Example.Reason>
+  `stateName` is controlled by the service and is documented as read-only,
+  signaling to clients that they cannot set it.
+</Example.Reason>
+
+</Example.Correct>
+
+<Workflow>
+  <Workflow.Step>Identify the server-owned fields in the schema.</Workflow.Step>
+  <Workflow.Step>Confirm each is documented as read-only.</Workflow.Step>
+  <Workflow.Step>
+    Flag any server-owned field not documented as read-only.
+  </Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
+<Guideline id="IPA-111-must-server-owned-read-only-true" given="schema" enforcement="automatable" effort="check">
+
+In OpenAPI, server-owned fields **must** have `readOnly: true`
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        stateName:
+          type: string
+          readOnly: true
+```
+
+<Example.Reason>
+  The server-owned `stateName` field sets `readOnly: true`, the OpenAPI
+  mechanism for marking a field as not settable by the client.
+</Example.Reason>
+
+</Example.Correct>
+
+</Guideline.Details>
+
+</Guideline>
+
+<Guideline id="IPA-111-must-not-accept-server-owned-in-request" given="schema" enforcement="review" effort="reason">
+
+Server-owned fields **must not** be accepted in request bodies for
+[Create](0106.mdx) or [Update](0107.mdx) operations
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        clusterName:
+          type: string
+        stateName:
+          type: string
+          readOnly: true
+```
+
+<Example.Reason>
+  `stateName` is marked `readOnly: true`, so it is excluded from Create and
+  Update request bodies and the service ignores any client-supplied value.
+</Example.Reason>
+
+</Example.Correct>
+
+<Workflow>
+  <Workflow.Step>
+    For each Create or Update operation, inspect the request body schema.
+  </Workflow.Step>
+  <Workflow.Step>
+    Confirm no server-owned (read-only) field is accepted in the request body.
+  </Workflow.Step>
+  <Workflow.Step>
+    Flag operations that accept a server-owned field in their request body.
+  </Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
+<Guideline id="IPA-111-may-omit-server-owned" enforcement="advisory">
+
+Server-owned fields **may** be omitted if appropriate to the API
+
+- API Producers **should** document whether the server-owned field is
+  guaranteed, or if it can be omitted in the response
+
+</Guideline>
+
+<Guideline id="IPA-111-must-consider-undocumented-client-owned" given="schema" enforcement="review" effort="reason">
+
+All fields that are not explicitly documented as server-owned **must** be
+considered client-owned
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        clusterName:
+          type: string
+        stateName:
+          type: string
+          readOnly: true
+```
+
+<Example.Reason>
+  `stateName` is explicitly documented as server-owned via `readOnly: true`;
+  `clusterName` carries no such marking and is therefore client-owned.
+</Example.Reason>
+
+</Example.Correct>
+
+<Workflow>
+  <Workflow.Step>
+    For each field, check whether it is explicitly documented as server-owned.
+  </Workflow.Step>
+  <Workflow.Step>
+    Treat every field without that documentation as client-owned.
+  </Workflow.Step>
+  <Workflow.Step>
+    Flag fields whose intended client ownership conflicts with how the service
+    actually treats them.
+  </Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
+<Guideline id="IPA-111-must-respect-client-owned-values" given="schema" enforcement="review" effort="explore" implementation>
+
+The server **must** respect the value (or lack thereof) of all client-owned
+fields and not modify them
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        clusterName:
+          type: string
+```
+
+<Example.Reason>
+  `clusterName` is client-owned, so the service stores and returns whatever the
+  client provides without modifying it.
+</Example.Reason>
+
+</Example.Correct>
+
+<Workflow>
+  <Workflow.Step>
+    Set a client-owned field to a known value via a Create or Update operation.
+  </Workflow.Step>
+  <Workflow.Step>Retrieve the resource and inspect the field.</Workflow.Step>
+  <Workflow.Step>
+    Confirm the service did not modify the value the client sent. Flag any
+    client-owned field the server alters.
+  </Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
+<Guideline id="IPA-111-must-return-same-client-owned-value" given="schema" enforcement="review" effort="explore" implementation>
+
+The server **must** always return the same value the client sent (or absence of
+value) for client-owned fields
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        clusterName:
+          type: string
+```
+
+<Example.Reason>
+  For the client-owned `clusterName`, the service echoes back exactly the value
+  the client sent, or omits it if the client sent no value.
+</Example.Reason>
+
+</Example.Correct>
+
+<Workflow>
+  <Workflow.Step>
+    Send a client-owned field with a specific value, and separately send a
+    request omitting it.
+  </Workflow.Step>
+  <Workflow.Step>Retrieve the resource after each request.</Workflow.Step>
+  <Workflow.Step>
+    Confirm the response returns the same value the client sent, and the same
+    absence when no value was sent. Flag discrepancies.
+  </Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
+</Guidelines>
 
 :::note
 
@@ -46,6 +333,10 @@ For resources where all fields are server-owned, see
 There are instances where a service will allocate, generate, or calculate a
 value that may differ from what the client specified.
 
+<Guidelines>
+
+<Guideline id="IPA-111-must-express-effective-value-as-two-fields" given="schema" enforcement="review" effort="reason">
+
 An attribute with an effective value **must** be expressed as two fields in the
 API:
 
@@ -53,9 +344,115 @@ API:
   and **must not** be modified by the service
 - A **server-owned** read-only field that records the effective value decided on
   by the service
-  - Effective values **must** be named by prefixing `effective` to the mutable
-    field's name
-  - In OpenAPI, the effective value field **must** have `readOnly: true`
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        instanceSize:
+          type: string
+        effectiveInstanceSize:
+          type: string
+          readOnly: true
+```
+
+<Example.Reason>
+  The desired `instanceSize` is a client-owned mutable field, while
+  `effectiveInstanceSize` is a server-owned read-only field recording the value
+  the service decided on.
+</Example.Reason>
+
+</Example.Correct>
+
+<Workflow>
+  <Workflow.Step>
+    Identify attributes whose effective value may differ from what the client
+    specified.
+  </Workflow.Step>
+  <Workflow.Step>
+    Confirm each is expressed as two fields: a client-owned mutable field and a
+    server-owned read-only field.
+  </Workflow.Step>
+  <Workflow.Step>
+    Flag attributes that collapse the desired and effective values into a single
+    field.
+  </Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
+<Guideline id="IPA-111-must-prefix-effective" given="schema" enforcement="automatable" effort="check">
+
+Effective values **must** be named by prefixing `effective` to the mutable
+field's name
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        instanceSize:
+          type: string
+        effectiveInstanceSize:
+          type: string
+          readOnly: true
+```
+
+<Example.Reason>
+  The effective field is named `effectiveInstanceSize`, prefixing `effective` to
+  the mutable field name `instanceSize`.
+</Example.Reason>
+
+</Example.Correct>
+
+</Guideline.Details>
+
+</Guideline>
+
+<Guideline id="IPA-111-must-effective-value-read-only-true" given="schema" enforcement="automatable" effort="check">
+
+In OpenAPI, the effective value field **must** have `readOnly: true`
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    Cluster:
+      type: object
+      properties:
+        effectiveInstanceSize:
+          type: string
+          readOnly: true
+```
+
+<Example.Reason>
+  The `effectiveInstanceSize` field sets `readOnly: true`, marking the
+  server-decided effective value as not settable by the client.
+</Example.Reason>
+
+</Example.Correct>
+
+</Guideline.Details>
+
+</Guideline>
+
+</Guidelines>
 
 Example
 
@@ -73,9 +470,75 @@ the server may scale it up or down based on load.
 
 ### Boolean Values
 
-- Booleans **should** default to `false`
-  - Many serialization systems won’t distinguish `false` values from unset
-    values which introduces complications when a boolean defaults to `true`
+<Guidelines>
+
+<Guideline id="IPA-111-should-default-boolean-false" given="schema" enforcement="review" effort="check">
+
+Booleans **should** default to `false`
+
+- Many serialization systems won’t distinguish `false` values from unset values
+  which introduces complications when a boolean defaults to `true`
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```yaml
+components:
+  schemas:
+    ClusterDescriptionProcessArgs:
+      type: object
+      properties:
+        javascriptDisabled:
+          type: boolean
+          default: false
+```
+
+<Example.Reason>
+  The boolean is modeled as `javascriptDisabled` defaulting to `false`, so an
+  unset value and a `false` value mean the same thing and no user intervention
+  is required for the default.
+</Example.Reason>
+
+</Example.Correct>
+
+<Example.Incorrect>
+
+```yaml
+components:
+  schemas:
+    ClusterDescriptionProcessArgs:
+      type: object
+      properties:
+        javascriptEnabled:
+          type: boolean
+          default: true
+```
+
+<Example.Reason>
+  `javascriptEnabled` defaults to `true`, but many serialization systems cannot
+  distinguish `false` from unset, forcing users to always set the value
+  explicitly.
+</Example.Reason>
+
+</Example.Incorrect>
+
+<Workflow>
+  <Workflow.Step>
+    Identify the default value of each boolean field.
+  </Workflow.Step>
+  <Workflow.Step>
+    Confirm the default is `false`, renaming the field if necessary so the
+    `false` default carries the intended meaning.
+  </Workflow.Step>
+  <Workflow.Step>Flag boolean fields that default to `true`.</Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
+</Guidelines>
 
 Example
 


### PR DESCRIPTION
Wraps IPA-111 Server-Modified Values bullet guidelines into atomic `<Guideline>` components.

## Guidelines

| ID | Severity | Enforcement | Effort |
|---|---|---|---|
| `IPA-111-must-have-single-owner` | must | review | reason |
| `IPA-111-must-document-server-owned-read-only` | must | review | reason |
| `IPA-111-must-server-owned-read-only-true` | must | automatable | check |
| `IPA-111-must-not-accept-server-owned-in-request` | must | review | reason |
| `IPA-111-may-omit-server-owned` | may | advisory | — |
| `IPA-111-must-consider-undocumented-client-owned` | must | review | reason |
| `IPA-111-must-respect-client-owned-values` | must | review | explore |
| `IPA-111-must-return-same-client-owned-value` | must | review | explore |
| `IPA-111-must-express-effective-value-as-two-fields` | must | review | reason |
| `IPA-111-must-prefix-effective` | must | automatable | check |
| `IPA-111-must-effective-value-read-only-true` | must | automatable | check |
| `IPA-111-should-default-boolean-false` | should | review | check |

## Test plan

- [x] Every non-advisory guideline has `<Example.Correct>` + `<Example.Reason>`
- [x] Every `enforcement="review"` guideline has a `<Workflow>`
- [x] `advisory` guidelines have no `given` or details block
- [x] `npm run lint` passes
- [x] `npm run docusaurus:build` passes