### PR TITLE
feat(ipa): Clarify cascading guideline for IPA-108

### DIFF
--- a/ipa/general/0108.mdx
+++ b/ipa/general/0108.mdx
@@ -299,13 +299,15 @@ is deleted.
     resources.
   </Workflow.Step>
   <Workflow.Step>
-    If it can, read the Delete operation description and, where available, the handler source it maps to.
+    If it can, read the Delete operation description and, where available, the
+    handler source it maps to.
   </Workflow.Step>
   <Workflow.Step>
     Determine whether the operation automatically deletes its child resources.
   </Workflow.Step>
   <Workflow.Step>
-    Report any Delete operation that automatically deletes child resources without a validation error and without explicit opt-in.
+    Report any Delete operation that automatically deletes child resources
+    without a validation error and without explicit opt-in.
   </Workflow.Step>
 </Workflow>
 

--- a/ipa/general/0108.mdx
+++ b/ipa/general/0108.mdx
@@ -279,7 +279,7 @@ is deleted.
 {
   "error": 400,
   "reason": "Bad Request",
-  "detail": "The request content produced validation errors.",
+  "detail": "Please delete all clusters in this project before deleting the project.",
   "errorCode": "BAD_REQUEST",
   "parameters": []
 }

--- a/ipa/general/0108.mdx
+++ b/ipa/general/0108.mdx
@@ -266,6 +266,51 @@ wiped-out child resources may be quite challenging.
 
 <Guidelines>
 
+<Guideline id="IPA-108-must-not-delete-child-resources-by-default" given="delete-operation" enforcement="review" effort="reason">
+
+The API **must not** automatically delete child resources when a parent resource
+is deleted.
+
+<Guideline.Details>
+
+<Example.Correct>
+
+```json
+{
+  "error": 400,
+  "reason": "Bad Request",
+  "detail": "The request content produced validation errors.",
+  "errorCode": "BAD_REQUEST",
+  "parameters": []
+}
+```
+
+<Example.Reason>
+  The API fails with a validation error if child resources are present, instead
+  of deleting them. The validation should instruct the user which child
+  resources to delete first.
+</Example.Reason>
+
+</Example.Correct>
+
+<Workflow>
+  <Workflow.Step>
+    For each delete operation, determine whether the resource may have child
+    resources.
+  </Workflow.Step>
+  <Workflow.Step>
+    If it can, determine if the operation exposes a `cascading` query parameter.
+  </Workflow.Step>
+  <Workflow.Step>
+    Flag delete operations on resources with children that omit the `cascading`
+    parameter, forcing destructive deletes without an explicit opt-in.
+  </Workflow.Step>
+</Workflow>
+
+</Guideline.Details>
+
+</Guideline>
+
 <Guideline id="IPA-108-should-provide-cascading-parameter" given="delete-operation" enforcement="review" effort="reason">
 
 If an API allows deletion of a resource that may have child resources, the API

--- a/ipa/general/0108.mdx
+++ b/ipa/general/0108.mdx
@@ -266,7 +266,7 @@ wiped-out child resources may be quite challenging.
 
 <Guidelines>
 
-<Guideline id="IPA-108-must-not-delete-child-resources-by-default" given="delete-operation" enforcement="review" effort="reason">
+<Guideline id="IPA-108-must-not-delete-child-resources-by-default" given="delete-operation" enforcement="review" implementation effort="explore">
 
 The API **must not** automatically delete child resources when a parent resource
 is deleted.
@@ -295,15 +295,17 @@ is deleted.
 
 <Workflow>
   <Workflow.Step>
-    For each delete operation, determine whether the resource may have child
+    For each Delete operation, determine whether the resource may have child
     resources.
   </Workflow.Step>
   <Workflow.Step>
-    If it can, determine if the operation exposes a `cascading` query parameter.
+    If it can, read the Delete operation description and, where available, the handler source it maps to.
   </Workflow.Step>
   <Workflow.Step>
-    Flag delete operations on resources with children that omit the `cascading`
-    parameter, forcing destructive deletes without an explicit opt-in.
+    Determine whether the operation automatically deletes its child resources.
+  </Workflow.Step>
+  <Workflow.Step>
+    Report any Delete operation that automatically deletes child resources without a validation error and without explicit opt-in.
   </Workflow.Step>
 </Workflow>
 


### PR DESCRIPTION
Clarifies the cascading section of IPA-108: Delete by adding new rule that the API must not delete child resource by default when a parent resource is deleted. Sets up the expectation before presenting the cascading flag as rule nr. 2. 

Ticket: [CLOUDP-417158](https://jira.mongodb.org/browse/CLOUDP-417158)