### PR TITLE
fix: Resolve guideline dependency links

### DIFF
--- a/src/components/ipa/Guideline/Guideline.module.css
+++ b/src/components/ipa/Guideline/Guideline.module.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
 }
 
 .numbered {

--- a/src/components/ipa/Guideline/Guideline.module.css
+++ b/src/components/ipa/Guideline/Guideline.module.css
@@ -5,6 +5,10 @@
   scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
 }
 
+.root:target {
+  animation: guidelineTargetFlash 1.4s ease-out;
+}
+
 .numbered {
   counter-increment: number-circle;
 }
@@ -17,4 +21,24 @@
 .body {
   font-size: 1rem;
   line-height: 1.625;
+}
+
+@keyframes guidelineTargetFlash {
+  0% {
+    background-color: var(--ifm-color-primary-lightest);
+    box-shadow: 0 0 0 0.25rem var(--ifm-color-primary-lightest);
+  }
+
+  100% {
+    background-color: transparent;
+    box-shadow: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .root:target {
+    animation: none;
+    outline: 2px solid var(--ifm-color-primary);
+    outline-offset: 0.25rem;
+  }
 }

--- a/src/components/ipa/Guideline/Guideline.test.tsx
+++ b/src/components/ipa/Guideline/Guideline.test.tsx
@@ -21,6 +21,7 @@ describe("<Guideline> standalone", () => {
     const guideline = document.querySelector("[data-guideline-id]");
 
     expect(guideline?.tagName).toBe("DIV");
+    expect(guideline).toHaveAttribute("id", "IPA-001-must-test-a");
     expect(
       document.querySelector("[data-guideline-id] [aria-hidden='true']"),
     ).toBeNull();

--- a/src/components/ipa/Guideline/Guideline.test.tsx
+++ b/src/components/ipa/Guideline/Guideline.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useBrokenLinks from "@docusaurus/useBrokenLinks";
 
 import { Guideline } from "./index";
 import type { Guideline as GuidelineData } from "../../../types/guideline";
@@ -16,6 +17,10 @@ const minimalGuideline = {
 } satisfies GuidelineData;
 
 describe("<Guideline> standalone", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders as a standalone block without a numbering circle", () => {
     render(<Guideline {...minimalGuideline}>content</Guideline>);
     const guideline = document.querySelector("[data-guideline-id]");
@@ -25,5 +30,11 @@ describe("<Guideline> standalone", () => {
     expect(
       document.querySelector("[data-guideline-id] [aria-hidden='true']"),
     ).toBeNull();
+  });
+
+  it("registers the guideline anchor with the Docusaurus broken-link checker", () => {
+    const { collectAnchor } = vi.mocked(useBrokenLinks)();
+    render(<Guideline {...minimalGuideline}>content</Guideline>);
+    expect(collectAnchor).toHaveBeenCalledWith("IPA-001-must-test-a");
   });
 });

--- a/src/components/ipa/Guideline/GuidelineFooter.tsx
+++ b/src/components/ipa/Guideline/GuidelineFooter.tsx
@@ -7,7 +7,7 @@ import styles from "./GuidelineFooter.module.css";
 // IPA-107-must-use-http-patch → "Must Use HTTP Patch"
 function slugToTitle(id: string): string {
   const slug = id.split("-").slice(2).join("-");
-  return (slug || id)
+  return slug
     .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
@@ -19,7 +19,7 @@ function ipaNumber(id: string): number | null {
   if (prefix !== "IPA") return null;
 
   const parsed = Number(number);
-  return Number.isInteger(parsed) ? parsed : null;
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function hasGuidelineAnchor(id: string): boolean {
@@ -27,10 +27,11 @@ function hasGuidelineAnchor(id: string): boolean {
 }
 
 // "IPA-107-must-use-http-patch" → "IPA 107: Must Use HTTP Patch"
+// "IPA-107" → "IPA 107"
 function depLabel(depId: string): string {
-  if (!hasGuidelineAnchor(depId)) return depId;
-
   const num = ipaNumber(depId);
+  if (!hasGuidelineAnchor(depId)) return num !== null ? `IPA ${num}` : depId;
+
   const title = slugToTitle(depId);
   return num !== null ? `IPA ${num}: ${title}` : title;
 }
@@ -41,7 +42,8 @@ function depHref(depId: string, currentIpa: number): string {
   const depIpa = ipaNumber(depId);
   const hasAnchor = hasGuidelineAnchor(depId);
   const anchor = `#${depId}`;
-  if (!hasAnchor) return depIpa !== null ? `/${depIpa}` : anchor;
+  if (!hasAnchor)
+    return depIpa !== null && depIpa !== currentIpa ? `/${depIpa}` : anchor;
 
   return depIpa !== null && depIpa !== currentIpa
     ? `/${depIpa}${anchor}`

--- a/src/components/ipa/Guideline/GuidelineFooter.tsx
+++ b/src/components/ipa/Guideline/GuidelineFooter.tsx
@@ -38,7 +38,7 @@ function depLabel(depId: string): string {
 
 // Cross-IPA: /107#IPA-107-must-use-http-patch
 // Same-IPA:  #IPA-107-must-use-http-patch
-function depHref(depId: string, currentIpa: number): string {
+function dependencyHref(depId: string, currentIpa: number): string {
   const depIpa = ipaNumber(depId);
   const hasAnchor = hasGuidelineAnchor(depId);
   const anchor = `#${depId}`;
@@ -63,7 +63,7 @@ export function GuidelineFooter(): ReactElement | null {
         {guideline.dependsOn.map((depId) => (
           <Link
             key={depId}
-            to={depHref(depId, principle.id)}
+            to={dependencyHref(depId, principle.id)}
             className={styles.depTag}
           >
             {depLabel(depId)}

--- a/src/components/ipa/Guideline/GuidelineFooter.tsx
+++ b/src/components/ipa/Guideline/GuidelineFooter.tsx
@@ -1,12 +1,13 @@
 import type { ReactElement } from "react";
+import Link from "@docusaurus/Link";
 import { useGuideline } from "../../../hooks/useGuideline";
 import { usePrinciple } from "../../../hooks/usePrinciple";
 import styles from "./GuidelineFooter.module.css";
 
-// IPA-107-must-use-http-patch → "Use HTTP Patch"
+// IPA-107-must-use-http-patch → "Must Use HTTP Patch"
 function slugToTitle(id: string): string {
-  const slug = id.replace(/^IPA-\d{3}-(must|should|may)-/, "");
-  return slug
+  const slug = id.split("-").slice(2).join("-");
+  return (slug || id)
     .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
@@ -14,22 +15,34 @@ function slugToTitle(id: string): string {
 
 // IPA-107-must-use-http-patch → 107
 function ipaNumber(id: string): number | null {
-  const match = id.match(/^IPA-(\d{3})/);
-  return match ? parseInt(match[1], 10) : null;
+  const [prefix, number] = id.split("-");
+  if (prefix !== "IPA") return null;
+
+  const parsed = Number(number);
+  return Number.isInteger(parsed) ? parsed : null;
 }
 
-// "IPA-107-must-use-http-patch" → "IPA-107: Use HTTP Patch"
+function hasGuidelineAnchor(id: string): boolean {
+  return id.split("-").length > 2;
+}
+
+// "IPA-107-must-use-http-patch" → "IPA 107: Must Use HTTP Patch"
 function depLabel(depId: string): string {
+  if (!hasGuidelineAnchor(depId)) return depId;
+
   const num = ipaNumber(depId);
   const title = slugToTitle(depId);
-  return num !== null ? `IPA-${num}: ${title}` : title;
+  return num !== null ? `IPA ${num}: ${title}` : title;
 }
 
 // Cross-IPA: /107#IPA-107-must-use-http-patch
 // Same-IPA:  #IPA-107-must-use-http-patch
 function depHref(depId: string, currentIpa: number): string {
   const depIpa = ipaNumber(depId);
+  const hasAnchor = hasGuidelineAnchor(depId);
   const anchor = `#${depId}`;
+  if (!hasAnchor) return depIpa !== null ? `/${depIpa}` : anchor;
+
   return depIpa !== null && depIpa !== currentIpa
     ? `/${depIpa}${anchor}`
     : anchor;
@@ -46,13 +59,13 @@ export function GuidelineFooter(): ReactElement | null {
       <span className={styles.label}>Depends on</span>
       <div className={styles.deps}>
         {guideline.dependsOn.map((depId) => (
-          <a
+          <Link
             key={depId}
-            href={depHref(depId, principle.id)}
+            to={depHref(depId, principle.id)}
             className={styles.depTag}
           >
             {depLabel(depId)}
-          </a>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/components/ipa/Guideline/index.tsx
+++ b/src/components/ipa/Guideline/index.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, type ReactElement } from "react";
+import useBrokenLinks from "@docusaurus/useBrokenLinks";
 import clsx from "clsx";
 import type { Guideline as GuidelineData } from "../../../types/guideline";
 import { GuidelineContext } from "../../../hooks/useGuideline";
@@ -18,12 +19,14 @@ function GuidelineBase({
   ...guideline
 }: GuidelineProps): ReactElement {
   const isInsideGuidelines = useIsInsideGuidelines();
+  useBrokenLinks().collectAnchor(guideline.id);
   const Root = isInsideGuidelines ? "li" : "div";
 
   return (
     <GuidelineContext.Provider value={{ guideline }}>
       <Root
         className={clsx(styles.root, isInsideGuidelines && styles.numbered)}
+        id={guideline.id}
         data-guideline-id={guideline.id}
       >
         {isInsideGuidelines && <NumberCircle />}

--- a/src/components/ipa/Guidelines/Guidelines.module.css
+++ b/src/components/ipa/Guidelines/Guidelines.module.css
@@ -2,8 +2,7 @@
   counter-reset: number-circle;
   list-style: none;
   margin: 2rem 0;
-  /* Horizontal padding only. */
-  padding: 0 1.5rem;
+  padding: 0;
   border-radius: 0.5rem;
   border: 1px solid var(--ifm-color-emphasis-200);
   background-color: var(--ifm-card-background-color);
@@ -11,9 +10,9 @@
   overflow: hidden;
 }
 
-/* Vertical padding per guideline. */
+/* Padding per guideline, so target highlights include the inset space. */
 .root > * {
-  padding: 1.5rem 0;
+  padding: 1.5rem;
 }
 
 /* Separator, centered between guidelines (mirrors the infima list-item margin). */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
     // Docusaurus aliases @site to the repo root; tests must match.
     alias: {
       "@site": fileURLToPath(new URL(".", import.meta.url)),
+      "@docusaurus/Link": "@docusaurus/core/lib/client/exports/Link",
+      "@docusaurus/useBrokenLinks":
+        "@docusaurus/core/lib/client/exports/useBrokenLinks",
       "@docusaurus/useDocusaurusContext":
         "@docusaurus/core/lib/client/exports/useDocusaurusContext",
     },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -15,9 +15,7 @@ vi.mock("@docusaurus/Link", () => ({
     createElement("a", { href: to ?? href, ...props }, children),
 }));
 
+const _brokenLinksMock = { collectAnchor: vi.fn(), collectLink: vi.fn() };
 vi.mock("@docusaurus/useBrokenLinks", () => ({
-  default: () => ({
-    collectAnchor: vi.fn(),
-    collectLink: vi.fn(),
-  }),
+  default: vi.fn(() => _brokenLinksMock),
 }));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,3 +7,17 @@
 //   `@docusaurus/*` and need stubs at unit-test time.
 
 import "@testing-library/jest-dom/vitest";
+import { createElement } from "react";
+import { vi } from "vitest";
+
+vi.mock("@docusaurus/Link", () => ({
+  default: ({ to, href, children, ...props }: any) =>
+    createElement("a", { href: to ?? href, ...props }, children),
+}));
+
+vi.mock("@docusaurus/useBrokenLinks", () => ({
+  default: () => ({
+    collectAnchor: vi.fn(),
+    collectLink: vi.fn(),
+  }),
+}));


### PR DESCRIPTION
## Ticket
[CLOUDP-416863](https://jira.mongodb.org/browse/CLOUDP-416863)

## Summary
Fixed the links in `dependsOn` to navaigate to the referenced IPA guideline

https://github.com/user-attachments/assets/d844e14c-0f67-4efc-b2e8-c920f695a55e

## Validation
- [x] npm test
- [x] npm run docusaurus:build
- [x] served locally and checked same-page/cross-IPA dependency links