### PR TITLE
feat(ipa): Disallow resetting to a default value for optional fields

### DIFF
--- a/ipa/general/0107.mdx
+++ b/ipa/general/0107.mdx
@@ -287,7 +287,7 @@ for all fields in the request (see
   - Any fields not included in the request body **must** be unset or set to
     their default value(s)
 - If the client explicitly provides `null` for an optional field in the request,
-  the server **should** unset the field or reset it to its default value
+  the server **should** unset the field
   - The server **should** return a
     [validation error](0114.mdx#validation-errors) if the client provides `null`
     for a field that is not nullable and cannot be unset
@@ -319,13 +319,12 @@ for all fields in the request (see
   </Workflow.Step>
   <Workflow.Step>
     For partial updates, confirm fields absent from the request body are left
-    unchanged. For full replacements, confirm absent fields are unset or reset
-    to their defaults.
+    unchanged. For full replacements, confirm absent fields are unset.
   </Workflow.Step>
   <Workflow.Step>
     Check `null` handling: an explicit `null` on an optional field should unset
-    it or reset it to its default, and a `null` on a non-nullable field that
-    cannot be unset should yield a validation error.
+    it, and a `null` on a non-nullable field that cannot be unset should yield a
+    validation error.
   </Workflow.Step>
   <Workflow.Step>
     Flag any field whose ownership is not respected, cross-checking client-owned

--- a/ipa/general/0107.mdx
+++ b/ipa/general/0107.mdx
@@ -284,8 +284,7 @@ for all fields in the request (see
   included in the request body and leave all other fields unchanged
 - For full resource replacements, the Update method **must** update the full
   resource to match the request
-  - Any fields not included in the request body **must** be unset or set to
-    their default value(s)
+  - Any fields not included in the request body **must** be unset
 - If the client explicitly provides `null` for an optional field in the request,
   the server **should** unset the field
   - The server **should** return a

--- a/ipa/general/0111.mdx
+++ b/ipa/general/0111.mdx
@@ -330,11 +330,11 @@ For resources where all fields are server-owned, see
 
 ### Optional Fields with Server Defaults
 
-Assigning a server-side default in place of a client-omitted value during
-resource creation is an anti-pattern: it creates hybrid ownership where the
-field is client-owned but the server effectively chooses a value. State-driven
-clients and downstream tooling then cannot tell whether a returned value was
-client-set or server-filled, and they report drift on every reconciliation.
+Assigning a server-side default in place of a client-omitted value is an
+anti-pattern: it creates hybrid ownership where the field is client-owned but
+the server effectively chooses a value. State-driven clients and downstream
+tooling then cannot tell whether a returned value was client-set or
+server-filled, and they report drift on every reconciliation.
 
 <Guidelines>
 


### PR DESCRIPTION
Assigning a server-side default in place of a client-omitted value is an anti-pattern. This PR removes every mention of resetting to a default.