### PR TITLE
docs(ipa0132): IPA-132 refinement

### DIFF
--- a/ipa/general/0132.mdx
+++ b/ipa/general/0132.mdx
@@ -957,6 +957,16 @@ An Operation **must** report progress through a `status` field.
   `SUCCEEDED`, `FAILED`, `CANCELED`, `SUPERSEDED`.
 - `SUCCEEDED` is the only success terminal state.
 
+Each value carries a fixed meaning:
+
+- `PENDING`: the request was accepted but work has not started.
+- `IN_PROGRESS`: work is currently executing.
+- `SUCCEEDED`: work completed successfully. This is the only success terminal
+  state.
+- `FAILED`: work completed unsuccessfully and reports a structured `error`.
+- `CANCELED`: work was terminated on request before completion.
+- `SUPERSEDED`: work was replaced by a later operation on the same resource.
+
 <Guideline.Details>
 
 <Example.Correct>
@@ -1265,7 +1275,7 @@ components:
 <Guideline id="IPA-132-operations-must-expire-after-a-finite-retention-period" given="lro-schema" enforcement="review" effort="explore" implementation dependsOn={["IPA-132-operation-endpoints-must-return-operation-response"]}>
 
 Operation records **must** be transient: they **must** expire after a finite
-retention period, exposed via an `expiredAt` timestamp on the Operation schema
+retention period, exposed via an `expiresAt` timestamp on the Operation schema
 indicating when this will happen. After expiry the Operations endpoint returns
 404; the underlying resource read is unaffected.
 
@@ -1279,7 +1289,7 @@ components:
     OperationResponse:
       type: object
       properties:
-        expiredAt:
+        expiresAt:
           type: string
           format: date-time
           description:
@@ -1288,7 +1298,7 @@ components:
 ```
 
 <Example.Reason>
-  The order operation record exposes an expiredAt timestamp that tells the
+  The order operation record exposes an expiresAt timestamp that tells the
   client when the record will return 404, so operation history remains transient
   and storage does not grow without bound.
 </Example.Reason>
@@ -1319,7 +1329,7 @@ components:
 <Workflow>
   <Workflow.Step>
     Confirm the Operation schema exposes an expiry timestamp (for example
-    expiredAt) and that the implementation enforces a finite TTL on terminal
+    expiresAt) and that the implementation enforces a finite TTL on terminal
     records.
   </Workflow.Step>
   <Workflow.Step>
@@ -1581,7 +1591,7 @@ paths:
   "updatedAt": "2026-07-01T12:01:00Z",
 
   // Required. When the Operation record expires and returns 404. Default retention ~30 days after terminal state.
-  "expiredAt": "2026-08-01T12:00:00Z"
+  "expiresAt": "2026-08-01T12:00:00Z"
 }
 ```
 
@@ -1596,7 +1606,7 @@ Example
   "resultHref": "https://api.example.com/orders/64f1b2e3c4d5e6f7a8b9c0d1",
   "createdAt": "2026-07-01T12:00:00Z",
   "updatedAt": "2026-07-01T12:03:00Z",
-  "expiredAt": "2026-08-01T12:00:00Z"
+  "expiresAt": "2026-08-01T12:00:00Z"
 }
 ```
 


### PR DESCRIPTION
Follow-up to #119, addressing Matt's two non-blocking review comments.

## Changes

**1. `expiredAt` → `expiresAt`** (6 occurrences in `ipa/general/0132.mdx`)

The field is a future deadline — when the terminal Operation record ages out — so present tense is correct. It also aligns with IPA-121, which already lists `expiresAt` as an example of correct timestamp naming.

The guideline id `IPA-132-operations-must-expire-after-a-finite-retention-period` does not contain the field name, so no anchor changed and no inbound `dependsOn` references broke.

**2. Document the `status` enum values**

The status-enum guideline previously asserted only enum membership and that `SUCCEEDED` is the sole success terminal. It now defines each value.

## Open question for review

`CANCELED` and `SUPERSEDED` have no emission rules anywhere in IPA-132 — nothing states who may set them or when. The definitions in this PR are a proposed reading, not something the document currently establishes. Those two lines are the part most worth scrutiny.

Separately, the `FAILED` line restates the structured-`error` requirement that is already stated normatively later in the file. Consistent, but it does put that rule in two places — happy to drop the clause.

Prettier passes; 34 tests pass.